### PR TITLE
Improve binop operation.

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -276,14 +276,14 @@ def BinOp : P4HIR_Op<"binop", [Pure,
     should be the same.
 
     ```mlir
-    %7 = p4hir.binop(add, %1, %2) : !p4hir.bit<32>
-    %7 = p4hir.binop(mul, %1, %2) : !p4hir.bit<32>
+    %3 = p4hir.binop(add, %1, %2) : !p4hir.bit<32>
+    %4 = p4hir.binop(mul, %1, %2) : !p4hir.bit<32>
     ```
   }];
 
-  let results = (outs BitsType:$result);
+  let results = (outs AnyIntP4Type:$result);
   let arguments = (ins Arg<BinOpKind, "binop kind">:$kind,
-                       BitsType:$lhs, BitsType:$rhs);
+                       AnyIntP4Type:$lhs, AnyIntP4Type:$rhs);
 
   let assemblyFormat = [{
     `(` $kind `,` $lhs `,` $rhs  `)` `:` type($lhs) attr-dict

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -281,17 +281,13 @@ def BinOp : P4HIR_Op<"binop", [Pure,
     ```
   }];
 
-  // TODO: get more accurate than AnyP4Type
-  let results = (outs AnyP4Type:$result);
+  let results = (outs BitsType:$result);
   let arguments = (ins Arg<BinOpKind, "binop kind">:$kind,
-                       AnyP4Type:$lhs, AnyP4Type:$rhs);
+                       BitsType:$lhs, BitsType:$rhs);
 
   let assemblyFormat = [{
     `(` $kind `,` $lhs `,` $rhs  `)` `:` type($lhs) attr-dict
   }];
-
-  // TODO: Implement verification
-  let hasVerifier = 0;
 }
 
 def ConcatOp : P4HIR_Op<"concat", [Pure]> {

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -218,6 +218,7 @@ def FuncType : P4HIR_Type<"Func", "func"> {
 
 def AnyP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType,
                            DontcareType, ErrorType, UnknownType]> {}
+def AnyIntP4Type : AnyTypeOf<[BitsType, InfIntType]> {}
 def CallResultP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, VoidType]> {}
 def LoadableP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType]> {}
 

--- a/test/Dialect/P4HIR/binop.mlir
+++ b/test/Dialect/P4HIR/binop.mlir
@@ -1,19 +1,36 @@
 // RUN: p4mlir-opt %s | FileCheck %s
 
+!u8i  = !p4hir.bit<8>
+!s8i  = !p4hir.int<8>
+
 // No need to check stuff. If it parses, it's fine.
 // CHECK: module
 module {
-  %0 = p4hir.const #p4hir.int<42> : !p4hir.bit<8>
-  %1 = p4hir.const #p4hir.int<42> : !p4hir.bit<8>
+  %lhs_u8i = p4hir.const #p4hir.int<42> : !u8i
+  %rhs_u8i = p4hir.const #p4hir.int<42> : !u8i
 
-  %2 = p4hir.binop(mul, %0, %1) : !p4hir.bit<8>
-  %3 = p4hir.binop(div, %0, %2) : !p4hir.bit<8>
-  %4 = p4hir.binop(mod, %0, %3) : !p4hir.bit<8>
-  %5 = p4hir.binop(add, %0, %4) : !p4hir.bit<8>
-  %6 = p4hir.binop(sub, %0, %5) : !p4hir.bit<8>
-  %7 = p4hir.binop(sadd, %0, %6) : !p4hir.bit<8>
-  %8 = p4hir.binop(ssub, %0, %7) : !p4hir.bit<8>
-  %9 = p4hir.binop(and, %0, %8) : !p4hir.bit<8>
-  %10 = p4hir.binop(or, %0, %9) : !p4hir.bit<8>
-  %11 = p4hir.binop(xor, %0, %10) : !p4hir.bit<8>  
+  %mul_u8i = p4hir.binop(mul, %lhs_u8i, %rhs_u8i) : !u8i
+  %div_u8i = p4hir.binop(div, %lhs_u8i, %rhs_u8i) : !u8i
+  %mod_u8i = p4hir.binop(mod, %lhs_u8i, %rhs_u8i) : !u8i
+  %add_u8i = p4hir.binop(add, %lhs_u8i, %rhs_u8i) : !u8i
+  %sub_u8i = p4hir.binop(sub, %lhs_u8i, %rhs_u8i) : !u8i
+  %sadd_u8i = p4hir.binop(sadd, %lhs_u8i, %rhs_u8i) : !u8i
+  %ssub_u8i = p4hir.binop(ssub, %lhs_u8i, %rhs_u8i) : !u8i
+  %and_u8i = p4hir.binop(and, %lhs_u8i, %rhs_u8i) : !u8i
+  %or_u8i = p4hir.binop(or, %lhs_u8i, %rhs_u8i) : !u8i
+  %xor_u8i = p4hir.binop(xor, %lhs_u8i, %rhs_u8i) : !u8i
+
+  %lhs_s8i = p4hir.const #p4hir.int<42> : !s8i
+  %rhs_s8i = p4hir.const #p4hir.int<42> : !s8i
+
+  %mul_s8i = p4hir.binop(mul, %lhs_s8i, %rhs_s8i) : !s8i
+  %div_s8i = p4hir.binop(div, %lhs_s8i, %rhs_s8i) : !s8i
+  %mod_s8i = p4hir.binop(mod, %lhs_s8i, %rhs_s8i) : !s8i
+  %add_s8i = p4hir.binop(add, %lhs_s8i, %rhs_s8i) : !s8i
+  %sub_s8i = p4hir.binop(sub, %lhs_s8i, %rhs_s8i) : !s8i
+  %sadd_s8i = p4hir.binop(sadd, %lhs_s8i, %rhs_s8i) : !s8i
+  %ssub_s8i = p4hir.binop(ssub, %lhs_s8i, %rhs_s8i) : !s8i
+  %and_s8i = p4hir.binop(and, %lhs_s8i, %rhs_s8i) : !s8i
+  %or_s8i = p4hir.binop(or, %lhs_s8i, %rhs_s8i) : !s8i
+  %xor_s8i = p4hir.binop(xor, %lhs_s8i, %rhs_s8i) : !s8i
 }

--- a/test/Dialect/P4HIR/binop.mlir
+++ b/test/Dialect/P4HIR/binop.mlir
@@ -1,11 +1,13 @@
 // RUN: p4mlir-opt %s | FileCheck %s
 
-!u8i  = !p4hir.bit<8>
-!s8i  = !p4hir.int<8>
+!u8i = !p4hir.bit<8>
+!s8i = !p4hir.int<8>
+!int = !p4hir.infint
 
 // No need to check stuff. If it parses, it's fine.
 // CHECK: module
 module {
+  // Operations on fixed-width bit types (unsigned integers)
   %lhs_u8i = p4hir.const #p4hir.int<42> : !u8i
   %rhs_u8i = p4hir.const #p4hir.int<42> : !u8i
 
@@ -20,6 +22,7 @@ module {
   %or_u8i = p4hir.binop(or, %lhs_u8i, %rhs_u8i) : !u8i
   %xor_u8i = p4hir.binop(xor, %lhs_u8i, %rhs_u8i) : !u8i
 
+  // Operations on fixed-width signed integers
   %lhs_s8i = p4hir.const #p4hir.int<42> : !s8i
   %rhs_s8i = p4hir.const #p4hir.int<42> : !s8i
 
@@ -33,4 +36,19 @@ module {
   %and_s8i = p4hir.binop(and, %lhs_s8i, %rhs_s8i) : !s8i
   %or_s8i = p4hir.binop(or, %lhs_s8i, %rhs_s8i) : !s8i
   %xor_s8i = p4hir.binop(xor, %lhs_s8i, %rhs_s8i) : !s8i
+
+  // Operations on arbitrary-precision integers
+  %lhs_int = p4hir.const #p4hir.int<42> : !int
+  %rhs_int = p4hir.const #p4hir.int<42> : !int
+
+  %mul_int = p4hir.binop(mul, %lhs_int, %rhs_int) : !int
+  %div_int = p4hir.binop(div, %lhs_int, %rhs_int) : !int
+  %mod_int = p4hir.binop(mod, %lhs_int, %rhs_int) : !int
+  %add_int = p4hir.binop(add, %lhs_int, %rhs_int) : !int
+  %sub_int = p4hir.binop(sub, %lhs_int, %rhs_int) : !int
+  %sadd_int = p4hir.binop(sadd, %lhs_int, %rhs_int) : !int
+  %ssub_int = p4hir.binop(ssub, %lhs_int, %rhs_int) : !int
+  %and_int = p4hir.binop(and, %lhs_int, %rhs_int) : !int
+  %or_int = p4hir.binop(or, %lhs_int, %rhs_int) : !int
+  %xor_int = p4hir.binop(xor, %lhs_int, %rhs_int) : !int
 }


### PR DESCRIPTION
Operation operands and result's type was changed to BitsType, MLIR test was changed to use operations on signed int operands.
Signed-off-by: Vladimir Shiryaev <w@tagolog.com>