### PR TITLE
Fix MacOS m chip build script

### DIFF
--- a/build_tools/build_p4c_with_p4mlir_ext.sh
+++ b/build_tools/build_p4c_with_p4mlir_ext.sh
@@ -20,14 +20,8 @@ P4C_EXT_DIR=$P4C_REPO_DIR/extensions
 
 P4C_P4MLIR_EXT_DIR=$P4C_EXT_DIR/p4mlir
 
-# if [[ "$(uname)" == "Darwin" ]]; then
-#     # macOS version
 P4C_P4MLIR_EXT_SYMLINK=$(realpath --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR" 2>/dev/null || \
 python3 -c 'import os, sys; print(os.path.relpath(sys.argv[2], start=sys.argv[1]))' "$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
-# else
-#     # Linux or other OS
-#     P4C_P4MLIR_EXT_SYMLINK=$(realpath -s --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
-# fi
 
 # Link P4MLIR as P4C extension
 mkdir -p "$P4C_EXT_DIR"

--- a/build_tools/build_p4c_with_p4mlir_ext.sh
+++ b/build_tools/build_p4c_with_p4mlir_ext.sh
@@ -19,7 +19,15 @@ P4C_BUILD_DIR=$P4C_REPO_DIR/build
 P4C_EXT_DIR=$P4C_REPO_DIR/extensions
 
 P4C_P4MLIR_EXT_DIR=$P4C_EXT_DIR/p4mlir
-P4C_P4MLIR_EXT_SYMLINK=$(realpath -s --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS version
+    P4C_P4MLIR_EXT_SYMLINK=$(realpath --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR" 2>/dev/null || \
+    python3 -c 'import os, sys; print(os.path.relpath(sys.argv[2], start=sys.argv[1]))' "$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
+else
+    # Linux or other OS
+    P4C_P4MLIR_EXT_SYMLINK=$(realpath -s --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
+fi
 
 # Link P4MLIR as P4C extension
 mkdir -p "$P4C_EXT_DIR"

--- a/build_tools/build_p4c_with_p4mlir_ext.sh
+++ b/build_tools/build_p4c_with_p4mlir_ext.sh
@@ -20,14 +20,14 @@ P4C_EXT_DIR=$P4C_REPO_DIR/extensions
 
 P4C_P4MLIR_EXT_DIR=$P4C_EXT_DIR/p4mlir
 
-if [[ "$(uname)" == "Darwin" ]]; then
-    # macOS version
-    P4C_P4MLIR_EXT_SYMLINK=$(realpath --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR" 2>/dev/null || \
-    python3 -c 'import os, sys; print(os.path.relpath(sys.argv[2], start=sys.argv[1]))' "$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
-else
-    # Linux or other OS
-    P4C_P4MLIR_EXT_SYMLINK=$(realpath -s --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
-fi
+# if [[ "$(uname)" == "Darwin" ]]; then
+#     # macOS version
+P4C_P4MLIR_EXT_SYMLINK=$(realpath --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR" 2>/dev/null || \
+python3 -c 'import os, sys; print(os.path.relpath(sys.argv[2], start=sys.argv[1]))' "$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
+# else
+#     # Linux or other OS
+#     P4C_P4MLIR_EXT_SYMLINK=$(realpath -s --relative-to="$(dirname "$P4C_P4MLIR_EXT_DIR")" "$P4MLIR_REPO_DIR")
+# fi
 
 # Link P4MLIR as P4C extension
 mkdir -p "$P4C_EXT_DIR"


### PR DESCRIPTION
Minor change to the build script, and solve the issue with https://github.com/p4lang/p4c/issues/5166

if somebody is going to build p4mlir, they need to put the necessary code into or organize it in a separate place, so they would not conflict with homebrew-installed ones: 

```
$ which bison
/opt/local/bin/bison
$ which flex
/opt/local/bin/flex
```
macOS building successfully:
```
3/4] Running the P4MLIR regression tests

Testing Time: 0.93s

Total Discovered Tests: 45
  Passed: 45 (100.00%)
```