### PR TITLE
typevar check v1

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1125,7 +1125,7 @@ def ExternOp : P4HIR_Op<"extern",
   let assemblyFormat = [{
     $sym_name (`<` $type_parameters^ `>`)? $body attr-dict
   }];
-
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     mlir::Block &createEntryBlock();
   }];

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -499,6 +499,11 @@ LogicalResult P4HIR::FuncOp::verifyType() {
             "The return type for a function returning void should "
             "be empty instead of an explicit !p4hir.void");
 
+    if (type.getReturnType().isa<P4HIR::TypeVarType>()) {
+        return emitOpError("type variables can only be used in declarations, "
+                            "but found in return type");
+    }
+
     return success();
 }
 
@@ -1425,6 +1430,17 @@ LogicalResult P4HIR::InstantiateOp::verifySymbolUses(SymbolTableCollection &symb
 mlir::Block &P4HIR::ExternOp::createEntryBlock() {
     assert(getBody().empty() && "can only create entry block for empty exern");
     return getBody().emplaceBlock();
+}
+
+LogicalResult P4HIR::ExternOp::verify() {
+    // TODO: 
+    // FunctionType type = getFunctionType();
+    // if (type.getReturnTypes().isa<P4HIR::TypeVarType>()) {
+    //     return emitOpError("type variables can only be used in declarations, "
+    //                        "but found in return type");
+    // }
+    // if (!getBody().empty()) return emitOpError("extern methods must not have a body");
+    return success();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is just a placeholder for discussion. I have done some research about the p4 extern function context and with your newly added support for extern func support at p4milr. 

Now the check will happen in three different places:
1. CallMethodOp
2. ExternOp
3. FuncOp

The current TODO verification in typevartype might lack context to solve the issue everywhere.
```
// CHECK:   p4hir.func @externFunc<!p4hir.type_var<"T">, !p4hir.type_var<"U">>(!p4hir.type_var<"U"> {p4hir.dir = #in}, !p4hir.type_var<"T"> {p4hir.dir = #in}) -> !p4hir.type_var<"T">
extern T externFunc<T, U>(in U a, in T b);
current output:

Failed Tests (4):
  P4MLIR :: Dialect/P4HIR/extern.mlir
  P4MLIR :: Translate/Ops/extern.p4
  P4MLIR :: Translate/Ops/extern_func.p4
  P4MLIR :: Translate/Parser/packet_in.p4


Testing Time: 2.22s

Total Discovered Tests: 52
  Passed: 48 (92.31%)
  Failed:  4 (7.69%)
```

