### PR TITLE
Some set of fixes appeared from running P4C tests

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ControlOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ControlOps.td
@@ -111,7 +111,7 @@ def TableEntryOp : P4HIR_Op<"table_entry", [
    ]> {
   let summary = "Represents a named P4 table entry";
   let description = [{
-  
+
   }];
 
   // TODO: Refine result type, need to allow externs as well as normal P4 types
@@ -136,7 +136,7 @@ def TableActionsOp : P4HIR_Op<"table_actions", [
        NoRegionArguments, NoTerminator]> {
   let summary = "Represents a list of actions for a P4 table";
   let description = [{
-  
+
   }];
 
   let regions = (region SizedRegion<1>:$body);
@@ -174,7 +174,7 @@ def TableDefaultActionOp : P4HIR_Op<"table_default_action", [
        NoRegionArguments, NoTerminator]> {
   let summary = "Represents a P4 table default action";
   let description = [{
-  
+
   }];
 
   let regions = (region SizedRegion<1>:$body);
@@ -197,7 +197,7 @@ def TableSizeOp : P4HIR_Op<"table_size",
    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>] > {
   let summary = "Represents a table size for a P4 table";
   let description = [{
-  
+
   }];
 
   let results = (outs AnyIntP4Type:$result);
@@ -212,7 +212,7 @@ def TableKeyOp : P4HIR_Op<"table_key",
   [NoRegionArguments, NoTerminator]> {
   let summary = "Represents a P4 table key";
   let description = [{
-  
+
   }];
 
   let regions = (region SizedRegion<1>:$body);
@@ -232,7 +232,7 @@ def TableKeyOp : P4HIR_Op<"table_key",
 def TableKeyEntryOp : P4HIR_Op<"match_key", []> {
   let summary = "Represents a P4 table key entry";
   let description = [{
-  
+
   }];
 
   let arguments = (ins P4HIR_MatchKindAttr:$match_kind, AnyP4Type:$value);
@@ -253,5 +253,18 @@ def TableKeyEntryOp : P4HIR_Op<"match_key", []> {
 
 }
 
-#endif // P4MLIR_DIALECT_P4HIR_P4HIR_CONTROLOPS_TD
+def ExitOp : P4HIR_Op<"exit", [ParentOneOf<["ScopeOp", "IfOp",
+                                            "FuncOp", "ControlApplyOp",]>]> {
+  let summary = "Represents an exit from action or control";
+  let description = [{
 
+  }];
+
+  // TODO: Check that it is invoked only inside action
+  let hasVerifier = 0;
+
+  // The return operation only emits the input in the format if it is present.
+  let assemblyFormat = [{ attr-dict }];
+}
+
+#endif // P4MLIR_DIALECT_P4HIR_P4HIR_CONTROLOPS_TD

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -679,7 +679,7 @@ def ReturnOp : P4HIR_Op<"return", [ParentOneOf<["ScopeOp", "IfOp",
   // We might not be able to have it a Terminator at this level in order
   // to represent dead code. We might lower it to proper terminator later (!)
   // See https://discourse.llvm.org/t/rfc-region-based-control-flow-with-early-exits-in-mlir/76998
-                                   Terminator]> {
+                                   ]> {
   let summary = "Return from function or action";
   let description = [{
     The "return" operation represents a return operation within a function or action.
@@ -718,6 +718,32 @@ def ReturnOp : P4HIR_Op<"return", [ParentOneOf<["ScopeOp", "IfOp",
   }];
 
   let hasVerifier = 1;
+}
+
+def ImplicitReturnOp : P4HIR_Op<"implicit_return",
+  [Terminator, ParentOneOf<["FuncOp"]>]> {
+  let summary = "Terminator return from the function";
+  let description = [{
+    Represents the terminator placeholder for returning from a function
+  }];
+
+  // The return operation takes an optional input operand to return. This
+  // value must match the return type of the enclosing function.
+  let arguments = (ins Variadic<AnyP4Type>:$input);
+
+  // The return operation only emits the input in the format if it is present.
+  let assemblyFormat = "($input^ `:` type($input))? attr-dict ";
+
+  // Allow building a ImplicitReturnOp with no return operand.
+  let builders = [
+    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
+  ];
+
+  let extraClassDeclaration = [{
+    bool hasOperand() { return getNumOperands() != 0; }
+  }];
+
+  let hasVerifier = 0;
 }
 
 def FuncOp : P4HIR_Op<"func", [

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -672,7 +672,9 @@ def AnyP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, StringType,
                            DontcareType, ErrorType, UnknownType,
                            SetType]> {}
 def AnyIntP4Type : AnyTypeOf<[BitsType, InfIntType]> {}
-def CallResultP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, VoidType]> {}
+def CallResultP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, VoidType,
+                                  StructType, HeaderType, Builtin_Tuple,
+                                  EnumType, SerEnumType]> {}
 def LoadableP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType,
                                 StructType, HeaderType, HeaderUnionType, Builtin_Tuple,
                                 EnumType, SerEnumType, ErrorType,

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -726,15 +726,16 @@ LogicalResult P4HIR::CallOp::verifySymbolUses(SymbolTableCollection &symbolTable
     auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("callee");
     if (!fnAttr) return emitOpError("requires a 'callee' symbol reference attribute");
     // Functions are defined at top-level scope
+
+    // TBD: overload set
     FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(getParentModule(*this), fnAttr);
     if (!fn) {
         // Actions might be defined both at top level and control scope
         fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(getParentControl(*this), fnAttr);
-        if (!fn.getAction())
+        if (!fn || !fn.getAction())
             return emitOpError() << "'" << fnAttr.getValue()
                                  << "' does not reference a valid action";
     }
-
     if (!fn)
         return emitOpError() << "'" << fnAttr.getValue() << "' does not reference a valid function";
 

--- a/test/Dialect/P4HIR/action.mlir
+++ b/test/Dialect/P4HIR/action.mlir
@@ -15,5 +15,5 @@ p4hir.func action @foo(%arg0 : !p4hir.ref<!bit32> {p4hir.dir = #p4hir<dir inout>
   p4hir.assign %arg1, %0 : <!bit32>
   p4hir.assign %1, %arg2 : <!bit32>
 
-  p4hir.return
+  p4hir.implicit_return
 }

--- a/test/Dialect/P4HIR/apply.mlir
+++ b/test/Dialect/P4HIR/apply.mlir
@@ -16,7 +16,7 @@ module {
     %inner = p4hir.instantiate @InnerPipe() as "inner" : () -> !InnerPipe
     p4hir.func action @bar() {
       %x1 = p4hir.variable ["x1"] : <!i16i>
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.control_apply {
       p4hir.call @bar () : () -> ()

--- a/test/Dialect/P4HIR/call.mlir
+++ b/test/Dialect/P4HIR/call.mlir
@@ -15,7 +15,7 @@ p4hir.func action @foo(%arg0 : !p4hir.ref<!bit32> {p4hir.dir = #p4hir<dir inout>
   p4hir.assign %arg1, %0 : !p4hir.ref<!bit32>
   p4hir.assign %1, %arg2 : !p4hir.ref<!bit32>
 
-  p4hir.return
+  p4hir.implicit_return
 }
 
 p4hir.func action @bar() {
@@ -24,5 +24,5 @@ p4hir.func action @bar() {
    %3 = p4hir.const #p4hir.int<7> : !i42i
    p4hir.call @foo(%0, %1, %0, %3) : (!p4hir.ref<!bit32>, !bit32, !p4hir.ref<!bit32>, !i42i) -> ()
 
-   p4hir.return
+   p4hir.implicit_return
 }

--- a/test/Dialect/P4HIR/control.mlir
+++ b/test/Dialect/P4HIR/control.mlir
@@ -19,7 +19,7 @@ module {
       %c4_i16i = p4hir.const #int4_i16i
       %cast = p4hir.cast(%c4_i16i : !i16i) : !i16i
       p4hir.assign %cast, %x1 : <!i16i>
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.func action @bar() {
       %c2_b10i = p4hir.const #int2_b10i
@@ -31,7 +31,7 @@ module {
       p4hir.assign %sub, %x1 : <!b10i>
       %val_0 = p4hir.read %x1 : <!b10i>
       p4hir.assign %val_0, %arg2 : <!b10i>
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.control_apply {
       %x1 = p4hir.variable ["x1", init] : <!b10i>

--- a/test/Dialect/P4HIR/exit.mlir
+++ b/test/Dialect/P4HIR/exit.mlir
@@ -1,0 +1,17 @@
+// RUN: p4mlir-opt --verify-roundtrip %s | FileCheck %s
+
+module {
+  // No need to check stuff. If it parses, it's fine.
+  // CHECK: module
+  %0 = p4hir.const #p4hir.bool<false> : !p4hir.bool
+  p4hir.if %0 {
+    %29 = p4hir.const #p4hir.bool<true> : !p4hir.bool
+    p4hir.exit
+  }
+
+  p4hir.if %0 {
+    %29 = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  } else {
+    %29 = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  }
+}

--- a/test/Dialect/P4HIR/extern.mlir
+++ b/test/Dialect/P4HIR/extern.mlir
@@ -59,7 +59,7 @@ module {
     %val = p4hir.read %arg0 : <!b32i>
     %call = p4hir.call @externFunc<[!b32i, !i7i]> (%arg1, %val) : (!i7i, !b32i) -> !b32i
     p4hir.assign %call, %arg0 : <!b32i>
-    p4hir.return
+    p4hir.implicit_return
   }
 
   p4hir.parser @p()() {

--- a/test/Dialect/P4HIR/header.mlir
+++ b/test/Dialect/P4HIR/header.mlir
@@ -39,6 +39,6 @@ module {
       %cast = p4hir.cast(%c36_b32i : !b32i) : !b32i
       p4hir.assign %cast, %y_field_ref : <!b32i>
     }
-    p4hir.return    
+    p4hir.implicit_return    
   }
 }

--- a/test/Dialect/P4HIR/slice.mlir
+++ b/test/Dialect/P4HIR/slice.mlir
@@ -41,6 +41,6 @@ module {
     p4hir.assign_slice %c0_b3i, %m[7 : 5] : !b3i -> <!b8i>
     %c0_b1i = p4hir.const #int0_b1i
     p4hir.assign_slice %c0_b1i, %x[5 : 5] : !b1i -> <!b8i>
-    p4hir.return
+    p4hir.implicit_return
   }
 }

--- a/test/Dialect/P4HIR/string.mlir
+++ b/test/Dialect/P4HIR/string.mlir
@@ -8,6 +8,6 @@ module {
     %cst = p4hir.const "This is a message" : !p4hir.string
     // CHECK: p4hir.call @log (%[[cst]]) : (!string) -> ()
     p4hir.call @log (%cst) : (!p4hir.string) -> ()
-    p4hir.return
+    p4hir.implicit_return
   }
 }

--- a/test/Dialect/P4HIR/struct.mlir
+++ b/test/Dialect/P4HIR/struct.mlir
@@ -23,7 +23,7 @@ module {
     %c1_b9i = p4hir.const #int1_b9i
     %add = p4hir.binop(add, %_v_0, %c1_b9i) : !b9i
     p4hir.assign %add, %_v : <!b9i>
-    p4hir.return
+    p4hir.implicit_return
   }
 
   p4hir.func action @test() {
@@ -32,6 +32,6 @@ module {
     %0 = p4hir.struct (%val) : !PortId_t
     %p1 = p4hir.variable ["p1", init] : <!PortId_t>
     p4hir.assign %0, %p1 : <!PortId_t>
-    p4hir.return    
+    p4hir.implicit_return    
   }
 }

--- a/test/Dialect/P4HIR/table.mlir
+++ b/test/Dialect/P4HIR/table.mlir
@@ -22,13 +22,13 @@ module {
   }
   p4hir.control @c(%arg0: !b32i)() {
     p4hir.func action @a(%arg1: !b32i {p4hir.dir = #undir}) {
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.func action @aa(%arg1: !b32i {p4hir.dir = #p4hir<dir in>}, %arg2: !i8i {p4hir.dir = #undir}) {
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.func action @b() {
-      p4hir.return
+      p4hir.implicit_return
     }
     p4hir.table @t1 {
       p4hir.table_actions {

--- a/test/Dialect/P4HIR/tuple.mlir
+++ b/test/Dialect/P4HIR/tuple.mlir
@@ -22,7 +22,7 @@ module {
     %t1 = p4hir.tuple_extract %val_4[1] : tuple<!b32i, !b16i>
     p4hir.assign %t1, %arg0 : <!b16i>
 
-    p4hir.return
+    p4hir.implicit_return
   }
 
   p4hir.func action @test2() {
@@ -34,6 +34,6 @@ module {
     %y = p4hir.variable ["y"] : <tuple<!b32i, !p4hir.bool>>
     %val = p4hir.read %x_0 : <tuple<!b32i, !p4hir.bool>>
     p4hir.assign %val, %y : <tuple<!b32i, !p4hir.bool>>
-    p4hir.return
+    p4hir.implicit_return
   }
 }

--- a/test/Translate/Ops/action.p4
+++ b/test/Translate/Ops/action.p4
@@ -1,7 +1,7 @@
 // RUN: p4mlir-translate --typeinference-only %s | FileCheck %s
 
 // CHECK-LABEL:   p4hir.func action @foo(%arg0: !b16i {p4hir.dir = #p4hir<dir in>}, %arg1: !p4hir.ref<!i10i> {p4hir.dir = #p4hir<dir inout>}, %arg2: !p4hir.ref<!b16i> {p4hir.dir = #p4hir<dir out>}, %arg3: !b16i {p4hir.dir = #p4hir<dir undir>})
-// CHECK:  p4hir.return
+// CHECK:  p4hir.implicit_return
 action foo(in bit<16> arg1, inout int<10> arg2, out bit<16> arg3, bit<16> arg4) {
     bit<16> x = arg1;
     arg3 = x;
@@ -12,6 +12,6 @@ action foo(in bit<16> arg1, inout int<10> arg2, out bit<16> arg3, bit<16> arg4) 
 }
 
 // CHECK-LABEL: p4hir.func action @bar(%arg0: !b16i {p4hir.dir = #p4hir<dir undir>}) {
-// CHECK:  p4hir.return
+// CHECK:  p4hir.implicit_return
 action bar(bit<16> arg1) {
 }

--- a/test/Translate/Ops/concat.p4
+++ b/test/Translate/Ops/concat.p4
@@ -71,7 +71,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !b5i, %[[VAL_7]] : !b5i) : !b10i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["r", init] : <!b10i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!b10i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_bit5_and_bit10() {
@@ -88,7 +88,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !b5i, %[[VAL_7]] : !b10i) : !b15i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!b15i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!b15i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_int5_and_int5() {
@@ -105,7 +105,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !i5i, %[[VAL_7]] : !i5i) : !i10i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!i10i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!i10i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_int5_and_int10() {
@@ -122,7 +122,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !i5i, %[[VAL_7]] : !i10i) : !i15i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!i15i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!i15i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_bit5_and_int5() {
@@ -139,7 +139,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !b5i, %[[VAL_7]] : !i5i) : !b10i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!b10i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!b10i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_bit5_and_int10() {
@@ -156,7 +156,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !b5i, %[[VAL_7]] : !i10i) : !b15i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!b15i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!b15i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_int5_and_bit5() {
@@ -173,7 +173,7 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !i5i, %[[VAL_7]] : !b5i) : !i10i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!i10i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!i10i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }
 
 // CHECK-LABEL:   p4hir.func action @concat_int5_and_bit10() {
@@ -190,5 +190,5 @@ action concat_int5_and_bit10() {
 // CHECK:           %[[VAL_8:.*]] = p4hir.concat(%[[VAL_6]] : !i5i, %[[VAL_7]] : !b10i) : !i15i
 // CHECK:           %[[VAL_9:.*]] = p4hir.variable ["result", init] : <!i15i>
 // CHECK:           p4hir.assign %[[VAL_8]], %[[VAL_9]] : <!i15i>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }

--- a/test/Translate/Ops/exit.p4
+++ b/test/Translate/Ops/exit.p4
@@ -1,0 +1,41 @@
+// RUN: p4mlir-translate --typeinference-only %s | FileCheck %s
+
+control ctrl() {
+    // CHECK-LABEL: p4hir.func action @e()
+    // CHECK: p4hir.exit
+    action e() {
+        exit;
+    }
+
+    table t {
+        actions = { e; }
+        default_action = e();
+    }
+
+    // CHECK-LABEL: p4hir.control_apply
+    apply {
+        bit<32> a;
+        bit<32> b;
+        bit<32> c;
+
+        a = 0;
+        b = 1;
+        c = 2;
+        if (t.apply().hit) {
+            b = 2;
+            t.apply();
+            c = 3;
+        } else {
+            b = 3;
+            t.apply();
+            c = 4;
+// CHECK: p4hir.exit            
+            exit;
+        }
+        c = 5;
+    }
+}
+
+control noop();
+package p(noop _n);
+p(ctrl()) main;

--- a/test/Translate/Ops/function.p4
+++ b/test/Translate/Ops/function.p4
@@ -6,6 +6,7 @@
 // CHECK:      p4hir.return %arg0 : !b16i
 // CHECK:    }
 // CHECK:    p4hir.return %arg1 : !b16i
+// CHECK:    p4hir.implicit_return
 // CHECK:  }
 
 bit<16> max(in bit<16> left, in bit<16> right) {
@@ -17,7 +18,7 @@ bit<16> max(in bit<16> left, in bit<16> right) {
 // CHECK-LABEL: p4hir.func action @bar(%arg0: !b16i {p4hir.dir = #in}, %arg1: !b16i {p4hir.dir = #in}, %arg2: !p4hir.ref<!b16i> {p4hir.dir = #p4hir<dir out>}) {
 // CHECK:    %[[CALL:.*]] = p4hir.call @max (%arg0, %arg1) : (!b16i, !b16i) -> !b16i
 // CHECK:    p4hir.assign %[[CALL]], %arg2 : <!b16i>
-// CHECK:    p4hir.return
+// CHECK:    p4hir.implicit_return
 
 action bar(in bit<16> arg1, in bit<16> arg2, out bit<16> res) {
   res = max(arg1, arg2);
@@ -60,5 +61,5 @@ action test_param() {
 // CHECK:      %[[A_OUT_VAL2:.*]] = p4hir.read %[[X_INOUT]] : <!b1i>
 // CHECK:      p4hir.assign %[[A_OUT_VAL2]], %[[A]] : <!b1i>
 // CHECK:    }
-// CHECK:    p4hir.return
+// CHECK:    p4hir.implicit_return
 // CHECK:  }

--- a/test/Translate/Ops/header.p4
+++ b/test/Translate/Ops/header.p4
@@ -70,7 +70,7 @@ action test1(inout Headers h) {
     // CHECK: %[[eq:.*]] = p4hir.cmp(eq, %[[val]], %[[valid]]) : !validity_bit, !p4hir.bool
     // CHECK: %[[not:.*]] = p4hir.unary(not, %[[eq]]) : !p4hir.bool
     // CHECK: p4hir.if %[[not]] {
-    // CHECK:   p4hir.return
+    // CHECK:   p4hir.implicit_return
     // CHECK: }
     if (!h.eth.isValid())
          return;
@@ -98,7 +98,7 @@ action assign_header() {
   // CHECK:           %[[e2:.*]] = p4hir.variable ["e2"] : <!Ethernet>
   // CHECK:           %[[val_e2:.*]] = p4hir.read %[[e2]] : <!Ethernet>
   // CHECK:           p4hir.assign %[[val_e2]], %[[e1]] : <!Ethernet>
-  // CHECK:           p4hir.return
+  // CHECK:           p4hir.implicit_return
 
   Ethernet e1;
   Ethernet e2;
@@ -112,7 +112,7 @@ action assign_invalid_header() {
   // CHECK:           %[[invalid:.*]] = p4hir.const #invalid
   // CHECK:           %[[__valid_field_ref:.*]] = p4hir.struct_extract_ref %[[e]]["__valid"] : <!Ethernet>
   // CHECK:           p4hir.assign %[[invalid]], %[[__valid_field_ref]] : <!validity_bit>
-  // CHECK:           p4hir.return
+  // CHECK:           p4hir.implicit_return
 
   Ethernet e;
 

--- a/test/Translate/Ops/header_union.p4
+++ b/test/Translate/Ops/header_union.p4
@@ -49,7 +49,7 @@ header_union U {
 // CHECK:           p4hir.if %[[VAL_17]] {
 // CHECK:             p4hir.return
 // CHECK:           }
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action header_union_isValid() {
   U u;
@@ -68,7 +68,7 @@ action header_union_isValid() {
 // CHECK:           %[[VAL_5:.*]] = p4hir.const #[[$ATTR_VALID]]
 // CHECK:           %[[VAL_6:.*]] = p4hir.struct_extract_ref %[[VAL_1]]["__valid"] : <!H1_>
 // CHECK:           p4hir.assign %[[VAL_5]], %[[VAL_6]] : <!validity_bit>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action header_setValid() {
   U u;
@@ -87,7 +87,7 @@ action header_setValid() {
 // CHECK:           %[[VAL_6:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_7:.*]] = p4hir.struct_extract_ref %[[VAL_5]]["__valid"] : <!H2_>
 // CHECK:           p4hir.assign %[[VAL_6]], %[[VAL_7]] : <!validity_bit>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action header_setInvalid() {
   U u;
@@ -109,7 +109,7 @@ action header_setInvalid() {
 // CHECK:           %[[VAL_2:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h1"] : <!U>
 // CHECK:           %[[VAL_9:.*]] = p4hir.read %[[VAL_1]] : <!H1_>
 // CHECK:           p4hir.assign %[[VAL_9]], %[[VAL_2]] : <!H1_>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action assign_header() {
   U u;
@@ -133,7 +133,7 @@ action assign_header() {
 // CHECK:           %[[VAL_9:.*]] = p4hir.const #[[$ATTR_VALID]]
 // CHECK:           %[[VAL_10:.*]] = p4hir.struct (%[[VAL_8]], %[[VAL_9]]) : !H1_
 // CHECK:           p4hir.assign %[[VAL_10]], %[[VAL_1]] : <!H1_>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action assign_tuple() {
   U u;
@@ -151,7 +151,7 @@ action assign_tuple() {
 // CHECK:           %[[VAL_6:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_7:.*]] = p4hir.struct_extract_ref %[[VAL_5]]["__valid"] : <!H2_>
 // CHECK:           p4hir.assign %[[VAL_6]], %[[VAL_7]] : <!validity_bit>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action assign_invalid_header() {
   U u;
@@ -164,7 +164,7 @@ action assign_invalid_header() {
 // CHECK:           %[[VAL_1:.*]] = p4hir.variable ["u2"] : <!U>
 // CHECK:           %[[VAL_2:.*]] = p4hir.read %[[VAL_0]] : <!U>
 // CHECK:           p4hir.assign %[[VAL_2]], %[[VAL_1]] : <!U>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action assign_header_union() {
   U u1;
@@ -183,7 +183,7 @@ action assign_header_union() {
 // CHECK:           %[[VAL_5:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_6:.*]] = p4hir.struct_extract_ref %[[VAL_4]]["__valid"] : <!H2_>
 // CHECK:           p4hir.assign %[[VAL_5]], %[[VAL_6]] : <!validity_bit>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action init_with_invalid_header_union() {
   U u = (U){#}; // invalid header union; same as an uninitialized header union.
@@ -199,7 +199,7 @@ action init_with_invalid_header_union() {
 // CHECK:           %[[VAL_5:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_6:.*]] = p4hir.struct_extract_ref %[[VAL_4]]["__valid"] : <!H2_>
 // CHECK:           p4hir.assign %[[VAL_5]], %[[VAL_6]] : <!validity_bit>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action assign_invalid_header_union() {
   U u;
@@ -213,7 +213,7 @@ action assign_invalid_header_union() {
 // CHECK:           %[[VAL_2:.*]] = p4hir.read %[[VAL_0]] : <!U>
 // CHECK:           %[[VAL_3:.*]] = p4hir.struct_extract %[[VAL_2]]["h1"] : !U
 // CHECK:           p4hir.assign %[[VAL_3]], %[[VAL_1]] : <!H1_>
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action get_header() {
   U u;
@@ -231,7 +231,7 @@ action get_header() {
 // CHECK:           p4hir.if %[[VAL_4]] {
 // CHECK:             p4hir.return
 // CHECK:           }
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action equ_header_unions() {
   U u1;
@@ -251,7 +251,7 @@ action equ_header_unions() {
 // CHECK:           p4hir.if %[[VAL_4]] {
 // CHECK:             p4hir.return
 // CHECK:           }
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action neq_header_unions() {
   U u1;
@@ -291,7 +291,7 @@ action neq_header_unions() {
 // CHECK:           p4hir.if %[[VAL_16]] {
 // CHECK:             p4hir.return
 // CHECK:           }
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action equ_with_invalid_header_union() {
   U u;
@@ -330,7 +330,7 @@ action equ_with_invalid_header_union() {
 // CHECK:           p4hir.if %[[VAL_16]] {
 // CHECK:             p4hir.return
 // CHECK:           }
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 
 action neq_with_invalid_header_union() {
   U u;

--- a/test/Translate/Ops/shl_shr.p4
+++ b/test/Translate/Ops/shl_shr.p4
@@ -87,5 +87,5 @@ action shl_shr() {
 // CHECK:           %[[VAL_41:.*]] = p4hir.variable ["s32i_shr_int", init] : <!i32i>
 // CHECK:           p4hir.assign %[[VAL_40]], %[[VAL_41]] : <!i32i>
 // CHECK:           %[[VAL_42:.*]] = p4hir.const ["int_shr_int"] #[[$ATTR_0]]
-// CHECK:           p4hir.return
+// CHECK:           p4hir.implicit_return
 // CHECK:         }

--- a/test/Translate/Ops/struct.p4
+++ b/test/Translate/Ops/struct.p4
@@ -73,7 +73,7 @@ action test2(inout PortId_t port) {
 // CHECK: %[[VAL:.*]] = p4hir.read %arg0 : <!PortId_t>
 // CHECK: %[[_V_VAL:.*]]  = p4hir.struct_extract %[[VAL]]["_v"] : !PortId_t
 // CHECK: p4hir.assign %{{.*}}, %[[_V_REF]]
-// CHECK: p4hir.return
+// CHECK: p4hir.implicit_return
 
 // CHECK-LABEL: p4hir.func action @test(%arg0: !p4hir.ref<!metadata_t> {p4hir.dir = #p4hir<dir inout>}) {
 // Just few important bits here        

--- a/tools/p4mlir-translate/main.cpp
+++ b/tools/p4mlir-translate/main.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "frontends/p4/directCalls.h"
 #include "frontends/p4/frontend.h"
 #include "frontends/p4/getV1ModelVersion.h"
+#include "frontends/p4/removeOpAssign.h"
 #include "frontends/p4/specialize.h"
 #include "frontends/p4/specializeGenericFunctions.h"
 #include "frontends/p4/specializeGenericTypes.h"
@@ -142,6 +143,7 @@ int main(int argc, char *const argv[]) {
                 new P4::CheckCoreMethods(&typeMap),
                 new P4::StructInitializers(&typeMap),  // TODO: Decide if we can do the same at MLIR
                                                        // level to reduce GC traffic
+                new P4::RemoveOpAssign(),              // TODO: Lower combined operations in MLIR
                 new P4::TypeChecking(nullptr, &typeMap, true),
             });
             passes.setName("TypeInference");

--- a/tools/p4mlir-translate/main.cpp
+++ b/tools/p4mlir-translate/main.cpp
@@ -21,14 +21,15 @@ limitations under the License.
 #include "frontends/p4/checkCoreMethods.h"
 #include "frontends/p4/checkNamedArgs.h"
 #include "frontends/p4/createBuiltins.h"
-#include "frontends/p4/directCalls.h"
 #include "frontends/p4/defaultArguments.h"
 #include "frontends/p4/defaultValues.h"
-#include "frontends/p4/getV1ModelVersion.h"
+#include "frontends/p4/directCalls.h"
 #include "frontends/p4/frontend.h"
+#include "frontends/p4/getV1ModelVersion.h"
 #include "frontends/p4/specialize.h"
 #include "frontends/p4/specializeGenericFunctions.h"
 #include "frontends/p4/specializeGenericTypes.h"
+#include "frontends/p4/structInitializers.h"
 #include "frontends/p4/toP4/toP4.h"
 #include "frontends/p4/typeChecking/bindVariables.h"
 #include "frontends/p4/validateParsedProgram.h"
@@ -139,6 +140,8 @@ int main(int argc, char *const argv[]) {
                     new P4::SpecializeGenericFunctions(&typeMap),
                 }),
                 new P4::CheckCoreMethods(&typeMap),
+                new P4::StructInitializers(&typeMap),  // TODO: Decide if we can do the same at MLIR
+                                                       // level to reduce GC traffic
                 new P4::TypeChecking(nullptr, &typeMap, true),
             });
             passes.setName("TypeInference");
@@ -178,8 +181,7 @@ int main(int argc, char *const argv[]) {
     if (!mod) return EXIT_FAILURE;
 
     mlir::OpPrintingFlags flags;
-    if (!options.noDump)
-      mod->print(llvm::outs(), flags.enableDebugInfo(options.printLoc));
+    if (!options.noDump) mod->print(llvm::outs(), flags.enableDebugInfo(options.printLoc));
 
     if (P4::Log::verbose()) std::cerr << "Done." << std::endl;
     return P4::errorCount() > 0 ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/tools/p4mlir-translate/options.cpp
+++ b/tools/p4mlir-translate/options.cpp
@@ -38,4 +38,11 @@ TranslateOptions::TranslateOptions() {
             return true;
         },
         "print location information in MLIR dump");
+    registerOption(
+        "--no-dump", nullptr,
+        [this](const char *) {
+            noDump = true;
+            return true;
+        },
+        "do not dump module on exit");
 }

--- a/tools/p4mlir-translate/options.h
+++ b/tools/p4mlir-translate/options.h
@@ -25,6 +25,7 @@ class TranslateOptions : public CompilerOptions {
     bool parseOnly = false;
     bool typeinferenceOnly = false;
     bool printLoc = false;
+    bool noDump = false;
 
     virtual ~TranslateOptions() = default;
 

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -539,6 +539,7 @@ class P4HIRConverter : public P4::Inspector, public P4::ResolutionContext {
     HANDLE_IN_POSTORDER(Cast)
     HANDLE_IN_POSTORDER(Declaration_Variable)
     HANDLE_IN_POSTORDER(ReturnStatement)
+    HANDLE_IN_POSTORDER(ExitStatement)
     HANDLE_IN_POSTORDER(ArrayIndex)
     HANDLE_IN_POSTORDER(Range)
     HANDLE_IN_POSTORDER(Mask)
@@ -1619,6 +1620,11 @@ void P4HIRConverter::postorder(const P4::IR::ReturnStatement *ret) {
     } else {
         builder.create<P4HIR::ReturnOp>(getLoc(builder, ret));
     }
+}
+void P4HIRConverter::postorder(const P4::IR::ExitStatement *ex) {
+    ConversionTracer trace("Converting ", ex);
+
+    builder.create<P4HIR::ExitOp>(getLoc(builder, ex));
 }
 
 mlir::Value P4HIRConverter::emitHeaderBuiltInMethod(mlir::Location loc,

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -53,10 +53,10 @@ mlir::Location getLoc(mlir::OpBuilder &builder, const P4::IR::Node *node) {
     if (!sourceInfo.isValid()) return mlir::UnknownLoc::get(builder.getContext());
 
     const auto &start = sourceInfo.getStart();
+    const auto &pos = sourceInfo.toPosition();
 
-    return mlir::FileLineColLoc::get(
-        builder.getStringAttr(sourceInfo.getSourceFile().string_view()), start.getLineNumber(),
-        start.getColumnNumber());
+    return mlir::FileLineColLoc::get(builder.getStringAttr(pos.fileName.string_view()),
+                                     pos.sourceLine, start.getColumnNumber());
 }
 
 mlir::Location getEndLoc(mlir::OpBuilder &builder, const P4::IR::Node *node) {

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1499,7 +1499,7 @@ bool P4HIRConverter::preorder(const P4::IR::Function *f) {
         mlir::Block &b = body.back();
         if (!b.mightHaveTerminator()) {
             builder.setInsertionPointToEnd(&b);
-            builder.create<P4HIR::ReturnOp>(getEndLoc(builder, f));
+            builder.create<P4HIR::ImplicitReturnOp>(getEndLoc(builder, f));
         }
     }
 
@@ -1607,7 +1607,7 @@ bool P4HIRConverter::preorder(const P4::IR::P4Action *act) {
         mlir::Block &b = body.back();
         if (!b.mightHaveTerminator()) {
             builder.setInsertionPointToEnd(&b);
-            builder.create<P4HIR::ReturnOp>(getEndLoc(builder, act));
+            builder.create<P4HIR::ImplicitReturnOp>(getEndLoc(builder, act));
         }
     }
 


### PR DESCRIPTION
 * Add support for Exit statement
 * `Return` operation is not a terminator for now, we will need to lower it to SESE regions later. Introduce `ImplicitReturn` operation that is a terminator.
 * Correctly resolve calls to overload sets (along with type checking, etc.)
 * Add some workaround for type inference bugs (mostly around serialized enums) – these will need to be fixed in the frontend eventually.
 * Lower few things (e.g. OpAssign nodes and some struct initializers) in the frontend