### PR TITLE
Second portion of fixes originated from P4C testsuite

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
@@ -2,7 +2,7 @@
 #define P4MLIR_DIALECT_P4HIR_P4HIR_PARSEROPS_TD
 
 def ParserOp : P4HIR_Op<"parser",
-    [Symbol, SymbolTable, IsolatedFromAbove,
+    [Symbol, SymbolTable,
      FunctionOpInterface, AutomaticAllocationScope]> {
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FuncType>:$applyType,

--- a/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
@@ -73,10 +73,8 @@ void IntAttr::print(AsmPrinter &printer) const {
     if (auto aliasType = mlir::dyn_cast<P4HIR::AliasType>(type)) type = aliasType.getAliasedType();
 
     if (auto bitsType = mlir::dyn_cast<BitsType>(type)) {
-        if (bitsType.isSigned())
-            printer << getSInt();
-        else
-            printer << getUInt();
+        APInt val = getValue();
+        val.print(printer.getStream(), bitsType.isSigned());
     } else
         printer << getValue();
 

--- a/test/Translate/Control/table_basic.p4
+++ b/test/Translate/Control/table_basic.p4
@@ -57,8 +57,7 @@ control c(in bit<32> arg) {
         some_entry = 10;
         implementation = ActionProfile(32);
        // CHECK:%implementation = p4hir.table_entry "implementation" {
-       // CHECK: %c32_b32i = p4hir.const #int32_b32i
-       // CHECK: %ActionProfile = p4hir.instantiate @ActionProfile(%c32_b32i) as "ActionProfile" : (!b32i) -> !ActionProfile
+       // CHECK: %ActionProfile = p4hir.instantiate @ActionProfile(%{{.*}}) as "ActionProfile" : (!b32i) -> !ActionProfile
        // CHECK: p4hir.yield %ActionProfile : !ActionProfile
        // CHECK:} : !ActionProfile        
     }

--- a/test/Translate/Ops/header_union.p4
+++ b/test/Translate/Ops/header_union.p4
@@ -60,11 +60,11 @@ action header_union_isValid() {
 
 // CHECK-LABEL:   p4hir.func action @header_setValid
 // CHECK:           %[[VAL_0:.*]] = p4hir.variable ["u"] : <!U>
-// CHECK:           %[[VAL_1:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h1"] : <!U>
 // CHECK:           %[[VAL_2:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h2"] : <!U>
 // CHECK:           %[[VAL_3:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_4:.*]] = p4hir.struct_extract_ref %[[VAL_2]]["__valid"] : <!H2_>
 // CHECK:           p4hir.assign %[[VAL_3]], %[[VAL_4]] : <!validity_bit>
+// CHECK:           %[[VAL_1:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h1"] : <!U>
 // CHECK:           %[[VAL_5:.*]] = p4hir.const #[[$ATTR_VALID]]
 // CHECK:           %[[VAL_6:.*]] = p4hir.struct_extract_ref %[[VAL_1]]["__valid"] : <!H1_>
 // CHECK:           p4hir.assign %[[VAL_5]], %[[VAL_6]] : <!validity_bit>
@@ -78,7 +78,6 @@ action header_setValid() {
 
 // CHECK-LABEL:   p4hir.func action @header_setInvalid
 // CHECK:           %[[VAL_0:.*]] = p4hir.variable ["u"] : <!U>
-// CHECK:           %[[VAL_1:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h1"] : <!U>
 // CHECK:           %[[VAL_2:.*]] = p4hir.struct_extract_ref %[[VAL_0]]["h1"] : <!U>
 // CHECK:           %[[VAL_3:.*]] = p4hir.const #[[$ATTR_INVALID]]
 // CHECK:           %[[VAL_4:.*]] = p4hir.struct_extract_ref %[[VAL_2]]["__valid"] : <!H1_>

--- a/test/Translate/Ops/newtype.p4
+++ b/test/Translate/Ops/newtype.p4
@@ -11,7 +11,7 @@ type Wide_t Wide;
 // CHECK: #int3_b32i = #p4hir.int<3> : !b32i
 // CHECK: #int192_Narrow = #p4hir.int<192> : !Narrow
 
-// CHECK: p4hir.const ["PSA_CPU_PORT"] #int192_Narrow
+// CHECK: %[[PSA_CPU_PORT:.*]] = p4hir.const ["PSA_CPU_PORT"] #int192_Narrow
 const Narrow PSA_CPU_PORT = (Narrow) 9w192; // target-specific
 
 // CHECK-LABEL: p4hir.func action @c
@@ -19,7 +19,6 @@ action c(out bool b) {
         Wide x = (Wide)3;
         Narrow y = (Narrow)(Narrow_t)(Wide_t)x;
 // CHECK: %[[y:.*]] = p4hir.variable ["y", init] : <!Narrow>
-// CHECK: %[[PSA_CPU_PORT:.*]] = p4hir.const ["PSA_CPU_PORT"] #int192_Narrow
 // CHECK: p4hir.assign %[[PSA_CPU_PORT]], %[[y]] : <!Narrow>
         y = PSA_CPU_PORT;
         b = y == (Narrow)10;

--- a/test/Translate/Ops/struct.p4
+++ b/test/Translate/Ops/struct.p4
@@ -58,6 +58,7 @@ const T t2 = s1.s1;
 
 struct PortId_t { bit<9> _v; }
 
+// CHECK: %[[PSA_CPU_PORT:.*]] = p4hir.const ["PSA_CPU_PORT"] #p4hir.aggregate<[#int192_b9i]> : !PortId_t
 const PortId_t PSA_CPU_PORT = { _v = 9w192 };
 
 struct metadata_t {
@@ -103,7 +104,6 @@ action test(inout metadata_t meta) {
                 
    // CHECK: %[[METADATA_VAL:.*]] = p4hir.read %arg0 : <!metadata_t>
    // CHECK: %[[FOO:.*]] = p4hir.struct_extract %[[METADATA_VAL]]["foo"] : !metadata_t
-   // CHECK: %[[PSA_CPU_PORT:.*]] = p4hir.const ["PSA_CPU_PORT"] #p4hir.aggregate<[#int192_b9i]> : !PortId_t
    // CHECK: %eq = p4hir.cmp(eq, %[[FOO]], %[[PSA_CPU_PORT]]) : !PortId_t, !p4hir.bool
    if (meta.foo == PSA_CPU_PORT) {
        meta.foo._v = meta.foo._v + 1;

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1955,13 +1955,8 @@ bool P4HIRConverter::preorder(const P4::IR::ConstructorCallExpression *cce) {
     llvm::SmallVector<mlir::Value, 4> operands;
     for (const auto *arg : *cce->arguments) {
         ConversionTracer trace("Converting ", arg);
-        mlir::Value argVal;
-        if (const auto *cce = arg->expression->to<P4::IR::ConstructorCallExpression>()) {
-            visit(cce);
-            argVal = getValue(cce);
-        } else
-            argVal = materializeConstantExpr(arg->expression);
-        operands.push_back(argVal);
+        visit(arg->expression);
+        operands.push_back(getValue(arg->expression));
     }
 
     auto resultType = getOrCreateType(type);
@@ -2324,13 +2319,8 @@ bool P4HIRConverter::preorder(const P4::IR::Declaration_Instance *decl) {
     llvm::SmallVector<mlir::Value, 4> operands;
     for (const auto *arg : *decl->arguments) {
         ConversionTracer trace("Converting ", arg);
-        mlir::Value argVal;
-        if (const auto *cce = arg->expression->to<P4::IR::ConstructorCallExpression>()) {
-            visit(cce);
-            argVal = getValue(cce);
-        } else
-            argVal = materializeConstantExpr(arg->expression);
-        operands.push_back(argVal);
+        visit(arg->expression);
+        operands.push_back(getValue(arg->expression));
     }
 
     auto resultType = getOrCreateType(type);

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1032,16 +1032,7 @@ mlir::TypedAttr P4HIRConverter::getOrCreateConstantExpr(const P4::IR::Expression
 
         // Fold some conversions
         if (auto destBitsType = mlir::dyn_cast<P4HIR::BitsType>(destType)) {
-            // Sign conversions
-            if (auto srcBitsType = mlir::dyn_cast<P4HIR::BitsType>(srcType)) {
-                assert(destBitsType.getWidth() == srcBitsType.getWidth() &&
-                       "expected signess conversion only");
-                auto castee = mlir::cast<P4HIR::IntAttr>(getOrCreateConstantExpr(cast->expr));
-                return setConstantExpr(
-                    expr, P4HIR::IntAttr::get(context(), destBitsType, castee.getValue()));
-            }
-            // Add bitwidth
-            if (auto srcIntType = mlir::dyn_cast<P4HIR::InfIntType>(srcType)) {
+            if (mlir::isa<P4HIR::BitsType, P4HIR::InfIntType>(srcType)) {
                 auto castee = mlir::cast<P4HIR::IntAttr>(getOrCreateConstantExpr(cast->expr));
                 return setConstantExpr(
                     expr,

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -346,6 +346,8 @@ class P4HIRConverter : public P4::Inspector, public P4::ResolutionContext {
     // Returns underlying type in case of something of serialized enum cate
     mlir::Type getIntType(const P4::IR::Type *type) {
         auto baseType = getOrCreateType(type);
+        if (auto aliasType = mlir::dyn_cast<P4HIR::AliasType>(baseType))
+            baseType = aliasType.getAliasedType();
         if (auto serEnumType = mlir::dyn_cast<P4HIR::SerEnumType>(baseType))
             baseType = serEnumType.getType();
         return baseType;

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1102,6 +1102,18 @@ mlir::TypedAttr P4HIRConverter::getOrCreateConstantExpr(const P4::IR::Expression
             BUG("invalid member reference %1%", m);
     }
 
+    if (const auto *eq = expr->to<P4::IR::Equ>()) {
+        auto lhs = getOrCreateConstantExpr(eq->left);
+        auto rhs = getOrCreateConstantExpr(eq->right);
+        return setConstantExpr(expr, P4HIR::BoolAttr::get(context(), lhs == rhs));
+    }
+
+    if (const auto *eq = expr->to<P4::IR::Neq>()) {
+        auto lhs = getOrCreateConstantExpr(eq->left);
+        auto rhs = getOrCreateConstantExpr(eq->right);
+        return setConstantExpr(expr, P4HIR::BoolAttr::get(context(), lhs != rhs));
+    }
+
     BUG("cannot resolve this constant expression yet %1% (aka %2%)", expr, dbp(expr));
 }
 

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -498,6 +498,10 @@ class P4HIRConverter : public P4::Inspector, public P4::ResolutionContext {
         // Should be resolved eslewhere
         return false;
     }
+    bool preorder(const P4::IR::EmptyStatement *e) override {
+        // Well, it's empty
+        return false;
+    }
 
 #define HANDLE_IN_POSTORDER(NodeTy)                                 \
     bool preorder(const P4::IR::NodeTy *) override { return true; } \

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1498,8 +1498,9 @@ bool P4HIRConverter::preorder(const P4::IR::AssignmentStatement *assign) {
         builder.create<P4HIR::AssignSliceOp>(loc, getValue(assign->right), ref, h, l);
     } else {
         auto ref = resolveReference(assign->left);
+        auto objectType = mlir::cast<P4HIR::ReferenceType>(ref.getType()).getObjectType();
         visit(assign->right);
-        builder.create<P4HIR::AssignOp>(loc, getValue(assign->right), ref);
+        builder.create<P4HIR::AssignOp>(loc, getValue(assign->right, objectType), ref);
     }
 
     return false;


### PR DESCRIPTION
 * More constfolding patterns
 * Fix lack of explicit casts for `Type_SerEnum` and `Type_NewType`
 * Correctly handle slices around in / inout / out arguments
 * Fix scope checks for actions
 * Handle `EmptyStatement`
 * Allow packages / functions to be overloaded
 * Handle arguments passed by names