### PR TITLE
First draft of ArrayType

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1126,6 +1126,51 @@ def StructExtractRefOp : P4HIR_Op<"struct_extract_ref",
   }];
 }
 
+
+def ArrayCreateOp : P4HIR_Op<"array_create", 
+  [Pure,
+   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Create an array of a specific type and size";
+  let description = [{
+    Creates an array with the specified element value and size value.
+    %arr = p4hir.array_create %element, %size : !p4hir.bool, i32 -> !p4hir.array<!p4hir.bool, !p4hir.bit<32>>
+  }];
+
+  let arguments = (ins AnyP4Type:$element, AnyP4Type:$size);
+  let results = (outs ArrayType:$result);
+
+  let hasVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
+}
+
+def ArraySetOp : P4HIR_Op<"array_set", [Pure]> {
+  let summary = "Set an element in an array at a given index";
+  let description = [{
+    Sets an element in an array at the specified index.
+    Example:
+    ```mlir
+    %new_arr = p4hir.array_set %arr[2], %value : !p4hir.array<!p4hir.bit<32>, 4> -> !p4hir.array<!p4hir.bit<32>, 4>
+    ```
+  }];
+
+  let arguments = (ins ArrayType:$arr, I32Attr:$index, AnyP4Type:$value);
+  let results = (outs ArrayType:$result);
+  
+  let assemblyFormat = [{
+    $arr `[` $index `]` `,` $value attr-dict `:` type($arr) `,` type($value) `->` type($result)
+  }];
+
+  // let skipDefaultBuilders = 1;
+  let hasVerifier = 0;
+  // TODO: Add verifier and Builders
+  // let builders = [
+  //   OpBuilder<(ins "mlir::Value":$arr, "unsigned":$index, "mlir::Value":$value), [{
+  //     auto arrayType = arr.getType().cast<ArrayType>();
+  //     build($_builder, $_state, arrayType, arr, index, value);
+  //   }]>
+  // ];
+}
+
 def TupleOp : P4HIR_Op<"tuple",
   [Pure,
    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -513,6 +513,42 @@ def ValidBitType : P4HIR_Type<"ValidBit", "validity.bit"> {
   }];
 }
 
+
+// ===----------------------------------------------------------------------===//
+// ArrayType
+// ===----------------------------------------------------------------------===//
+def ArrayType : P4HIR_Type<"Array", "array"> {
+  let summary = "array type";
+  let description = [{
+    An array of values of a specific type.
+    !p4hir.array<!p4hir.bit<32>, 4>
+  }];
+
+  let parameters = (ins "mlir::Type":$elementType, "unsigned":$size);
+
+  let assemblyFormat = [{
+    `<` $elementType `,` $size `>`
+  }];
+  
+  let builders = [
+    TypeBuilder<(ins "mlir::Type":$elementType, "unsigned":$size)>
+  ];
+  
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Returns true if the array is empty
+    bool isEmpty() const { return getSize() == 0; }
+
+    /// Returns true if the index is valid
+    bool isValidIndex(unsigned index) const { return index < getSize(); }
+    
+    void getInnerTypes(mlir::SmallVectorImpl<mlir::Type>& types) const {
+      types.push_back(getElementType());
+    }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // HeaderType
 //===----------------------------------------------------------------------===//
@@ -797,17 +833,17 @@ def AliasType : P4HIR_Type<"Alias", "alias", []> {
 //===----------------------------------------------------------------------===//
 
 def AnyP4Type : AnyTypeOf<[BitsType, VarBitsType, BooleanType, InfIntType, StringType,
-                           StructType, HeaderType, HeaderUnionType, Builtin_Tuple,
+                           StructType, HeaderType, HeaderUnionType, Builtin_Tuple, ArrayType,
                            EnumType, SerEnumType,
                            ValidBitType,
                            DontcareType, ErrorType, UnknownType, AliasType,
                            SetType]> {}
 def AnyIntP4Type : AnyTypeOf<[BitsType, InfIntType]> {}
 def CallResultP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, VoidType,
-                                  StructType, HeaderType, Builtin_Tuple,
+                                  StructType, HeaderType, Builtin_Tuple, ArrayType,
                                   EnumType, SerEnumType, AliasType]> {}
 def LoadableP4Type : AnyTypeOf<[BitsType, VarBitsType, BooleanType, InfIntType,
-                                StructType, HeaderType, HeaderUnionType, Builtin_Tuple,
+                                StructType, HeaderType, HeaderUnionType, Builtin_Tuple, ArrayType,
                                 EnumType, SerEnumType, ErrorType,
                                 ValidBitType, AliasType]> {}
 def AnyEnumType : AnyTypeOf<[EnumType, SerEnumType]>;

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -867,6 +867,9 @@ LogicalResult P4HIR::CallOp::verifySymbolUses(SymbolTableCollection &symbolTable
     return success();
 }
 
+//===----------------------------------------------------------------------===//
+// ArrayCreateOp
+//===----------------------------------------------------------------------===//
 void P4HIR::ArrayCreateOp::print(OpAsmPrinter &printer) {
     LLVM_DEBUG({
         llvm::dbgs() << "-----------------------------------\n";
@@ -884,13 +887,9 @@ void P4HIR::ArrayCreateOp::print(OpAsmPrinter &printer) {
     }
     llvm_unreachable("unknown P4HIR type");
 }
-//===----------------------------------------------------------------------===//
-// ArrayCreateOp
-//===----------------------------------------------------------------------===//
-ParseResult P4HIR::ArrayCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 
+ParseResult P4HIR::ArrayCreateOp::parse(OpAsmParser &parser, OperationState &result) {
     OpAsmParser::UnresolvedOperand elementOperand, sizeOperand;
-    
     if (parser.parseOperand(elementOperand) || 
         parser.parseComma() || 
         parser.parseOperand(sizeOperand))

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -871,13 +871,6 @@ LogicalResult P4HIR::CallOp::verifySymbolUses(SymbolTableCollection &symbolTable
 // ArrayCreateOp
 //===----------------------------------------------------------------------===//
 void P4HIR::ArrayCreateOp::print(OpAsmPrinter &printer) {
-    LLVM_DEBUG({
-        llvm::dbgs() << "-----------------------------------\n";
-        llvm::dbgs() << "Debug: Printing ArrayCreateOp with type: ";
-        getType().print(printer); 
-        llvm::dbgs() << "\n";
-    });
-
     if (auto arrayType = getType().dyn_cast<P4HIR::ArrayType>()) {
         printer << "array<";
         printer.printType(arrayType.getElementType());

--- a/lib/Dialect/P4HIR/P4HIR_Types.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Types.cpp
@@ -306,6 +306,13 @@ LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError, S
     return result;
 }
 
+LogicalResult ArrayType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                Type elementType, unsigned size) {
+  if (size <= 0)
+    return emitError() << "ArrayType size must be greater than 0";
+  return success();
+}
+
 LogicalResult HeaderType::verify(function_ref<InFlightDiagnostic()> emitError, StringRef,
                                  ArrayRef<FieldInfo> elements, DictionaryAttr) {
     if (elements.empty()) {

--- a/test/Dialect/P4HIR/array.mlir
+++ b/test/Dialect/P4HIR/array.mlir
@@ -1,0 +1,14 @@
+// RUN: p4mlir-opt --mlir-print-ir-after-failure --verify-roundtrip -debug-only=canonicalize %s | FileCheck %s
+
+#true = #p4hir.bool<true> : !p4hir.bool
+!int32i = !p4hir.int<32>
+
+// CHECK: module
+module {
+  // creating params - First const is true，second is 2.
+  %0 = p4hir.const #true
+  %1 = p4hir.const #p4hir.int<2> : !int32i
+  
+  // creating array - First param is true，second is 2.
+  %arr1 = p4hir.array_create %0, %1 : !p4hir.bool, !int32i -> !p4hir.array<!p4hir.bool, 3>
+}

--- a/test/Dialect/P4HIR/array.mlir
+++ b/test/Dialect/P4HIR/array.mlir
@@ -10,5 +10,5 @@ module {
   %1 = p4hir.const #p4hir.int<2> : !int32i
   
   // creating array - First param is true，second is 2.
-  %arr1 = p4hir.array_create %0, %1 : !p4hir.bool, !int32i -> !p4hir.array<!p4hir.bool, 3>
+  %arr1 = p4hir.array_create %0, %1 : !p4hir.bool, !int32i -> !p4hir.array<!p4hir.bool, 2>
 }

--- a/test/Translate/Ops/array.p4
+++ b/test/Translate/Ops/array.p4
@@ -1,0 +1,14 @@
+// RUN: p4mlir-translate --typeinference-only %s | FileCheck %s
+
+header Mpls_h {
+    bit<20> label;
+    bit<8> ttl;
+}
+
+struct S {
+    bit<8> label;
+    Mpls_h[10] mpls;
+}
+
+// FileCheck 
+// CHECK: module {


### PR DESCRIPTION
[WIP] Only for learning purposes and understanding the APIs: 
I have a practice patch halfway through for ArrayType, the stack_header could extend pop_front/push_front.

Implement an ArrayType: static ArrayType
```
ArrayType<elemtype, size>（use IntAttr)?
- Parse
- Print
- Verify
ArrayCreateOp
ArraySetOp
ArrayGetOp
ArrayLengthOp
array.mlir
array.p4
```
But when I try to parse the array.p4 file, it says: (error: <Type_Stack>(45): P4 type not yet supported) 
Does the frontend have some flags to open this? @qobilidop  and my array.p4 looks like:
```
header Mpls_h {
    bit<20> label;
    bit<8> ttl;
}

struct S {
    bit<8> label;
    Mpls_h[10] mpls;
}
```