### PR TITLE
Make ReturnOp take Optional operands

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -760,18 +760,18 @@ def ReturnOp : P4HIR_Op<"return", [ParentOneOf<["ScopeOp", "IfOp",
 
   // The return operation takes an optional input operand to return. This
   // value must match the return type of the enclosing function.
-  let arguments = (ins Variadic<AnyP4Type>:$input);
+  let arguments = (ins Optional<AnyP4Type>:$input);
 
   // The return operation only emits the input in the format if it is present.
-  let assemblyFormat = "($input^ `:` type($input))? attr-dict ";
+  let assemblyFormat = [{ ($input^ `:` type($input))? attr-dict }];
 
   // Allow building a ReturnOp with no return operand.
   let builders = [
-    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
+    OpBuilder<(ins), [{ build($_builder, $_state, nullptr); }]>
   ];
 
   let extraClassDeclaration = [{
-    bool hasOperand() { return getNumOperands() != 0; }
+    bool hasOperand() { return getInput() != nullptr; }
   }];
 
   let hasVerifier = 1;
@@ -1600,7 +1600,6 @@ let description = [{
 
   let hasCustomAssemblyFormat = 1;
 }
-
 
 def ConditionOp : P4HIR_Op<"condition",
         [HasParent<"ForOp">,

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -644,7 +644,7 @@ void P4HIR::IfOp::build(OpBuilder &builder, OperationState &result, Value cond, 
     elseBuilder(builder, result.location);
 }
 
-mlir::LogicalResult P4HIR::ReturnOp::verify() {
+LogicalResult P4HIR::ReturnOp::verify() {
     // Returns can be present in multiple different scopes, get the wrapping
     // function and start from there.
     auto fnOp = getOperation()->getParentOfType<FunctionOpInterface>();
@@ -653,13 +653,9 @@ mlir::LogicalResult P4HIR::ReturnOp::verify() {
                                 "actions and control apply blocks";
     }
 
-    // ReturnOps currently only have a single optional operand.
-    if (getNumOperands() > 1) return emitOpError() << "expects at most 1 return operand";
-
     // Ensure returned type matches the function signature.
     auto expectedTy = mlir::cast<P4HIR::FuncType>(fnOp.getFunctionType()).getReturnType();
-    auto actualTy =
-        (getNumOperands() == 0 ? P4HIR::VoidType::get(getContext()) : getOperand(0).getType());
+    auto actualTy = hasOperand() ? getInput().getType() : P4HIR::VoidType::get(getContext());
     if (actualTy != expectedTy)
         return emitOpError() << "returns " << actualTy << " but enclosing function returns "
                              << expectedTy;


### PR DESCRIPTION
Small thing I noticed while starting on the `continue` and `break` operations.

https://mlir.llvm.org/docs/DefiningDialects/Operations/#optional-operands