### PR TITLE
Add basic shift folds

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -416,6 +416,7 @@ def ShlOp : P4HIR_Op<"shl",
   ];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 
   let assemblyFormat = [{
     `(` $lhs `,` $rhs `:` type($rhs) `)` `:` type($result) attr-dict
@@ -453,6 +454,7 @@ def ShrOp : P4HIR_Op<"shr",
   ];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 
   let assemblyFormat = [{
     `(` $lhs `,` $rhs `:` type($rhs) `)` `:` type($result) attr-dict

--- a/test/Transforms/Folds/shl_shr.mlir
+++ b/test/Transforms/Folds/shl_shr.mlir
@@ -24,9 +24,10 @@
 #int62_infint = #p4hir.int<62> : !infint
 #int500_infint = #p4hir.int<500> : !infint
 #int128000_infint = #p4hir.int<128000> : !infint
+#int-1_infint = #p4hir.int<-1> : !infint
 #int-5_infint = #p4hir.int<-5> : !infint
 #int-40_infint = #p4hir.int<-40> : !infint
-#int-62_infint = #p4hir.int<-62> : !infint
+#int-63_infint = #p4hir.int<-63> : !infint
 #int-500_infint = #p4hir.int<-500> : !infint
 
 // CHECK: module
@@ -47,9 +48,10 @@ module  {
   // CHECK-DAG: %[[c62_infint:.*]] = p4hir.const #int62_infint
   // CHECK-DAG: %[[c500_infint:.*]] = p4hir.const #int500_infint
   // CHECK-DAG: %[[c128000_infint:.*]] = p4hir.const #int128000_infint
+  // CHECK-DAG: %[[cminus1_infint:.*]] = p4hir.const #int-1_infint
   // CHECK-DAG: %[[cminus5_infint:.*]] = p4hir.const #int-5_infint
   // CHECK-DAG: %[[cminus40_infint:.*]] = p4hir.const #int-40_infint
-  // CHECK-DAG: %[[cminus62_infint:.*]] = p4hir.const #int-62_infint
+  // CHECK-DAG: %[[cminus63_infint:.*]] = p4hir.const #int-63_infint
   // CHECK-DAG: %[[cminus500_infint:.*]] = p4hir.const #int-500_infint
   %c0_b8i = p4hir.const #int0_b8i
   %c3_b8i = p4hir.const #int3_b8i
@@ -66,9 +68,10 @@ module  {
   %c62_infint = p4hir.const #int62_infint
   %c500_infint = p4hir.const #int500_infint
   %c128000 = p4hir.const #int128000_infint
+  %c-1_infint = p4hir.const #int-1_infint
   %c-5_infint = p4hir.const #int-5_infint
   %c-40_infint = p4hir.const #int-40_infint
-  %c-62_infint = p4hir.const #int-62_infint
+  %c-63_infint = p4hir.const #int-63_infint
   %c-500_infint = p4hir.const #int-500_infint
 
   p4hir.func @blackhole_b8i(!b8i)
@@ -173,18 +176,16 @@ module  {
     %shr0 = p4hir.shr(%c5_infint, %c3_b8i : !b8i) : !infint // 5 >> 3 = 0
     p4hir.call @blackhole_infint(%shr0) : (!infint) -> ()
 
-    // NOTE: -5 >> 3 = -1, but -5 / (2 ^ 3) = 0
-    // CHECK: p4hir.call @blackhole_infint (%[[c0_infint]]) : (!infint) -> ()
-    %shr1 = p4hir.shr(%c-5_infint, %c3_b8i : !b8i) : !infint
+    // CHECK: p4hir.call @blackhole_infint (%[[cminus1_infint]]) : (!infint) -> ()
+    %shr1 = p4hir.shr(%c-5_infint, %c3_b8i : !b8i) : !infint // -5 >> 3 = -1
     p4hir.call @blackhole_infint(%shr1) : (!infint) -> ()
 
     // CHECK: p4hir.call @blackhole_infint (%[[c62_infint]]) : (!infint) -> ()
     %shr2 = p4hir.shr(%c500_infint, %c3_b8i : !b8i) : !infint // 500 >> 3 = 62
     p4hir.call @blackhole_infint(%shr2) : (!infint) -> ()
 
-    // NOTE: -500 >> 3 = -63, but -500 / (2 ^ 3) = -62
-    // CHECK: p4hir.call @blackhole_infint (%[[cminus62_infint]]) : (!infint) -> ()
-    %shr3 = p4hir.shr(%c-500_infint, %c3_b8i : !b8i) : !infint
+    // CHECK: p4hir.call @blackhole_infint (%[[cminus63_infint]]) : (!infint) -> ()
+    %shr3 = p4hir.shr(%c-500_infint, %c3_b8i : !b8i) : !infint // -500 >> 3 = -63
     p4hir.call @blackhole_infint(%shr3) : (!infint) -> ()
 
     p4hir.return
@@ -198,8 +199,9 @@ module  {
   p4hir.call @blackhole_infint(%c0_infint) : (!infint) -> ()
   p4hir.call @blackhole_infint(%c5_infint) : (!infint) -> ()
   p4hir.call @blackhole_infint(%c500_infint) : (!infint) -> ()
-  p4hir.call @blackhole_infint(%c-40_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c-1_infint) : (!infint) -> ()
   p4hir.call @blackhole_infint(%c-5_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c-40_infint) : (!infint) -> ()
   p4hir.call @blackhole_infint(%c-500_infint) : (!infint) -> ()
 }
 

--- a/test/Transforms/Folds/shl_shr.mlir
+++ b/test/Transforms/Folds/shl_shr.mlir
@@ -3,7 +3,7 @@
 !b4i = !p4hir.bit<4>
 !b8i = !p4hir.bit<8>
 !i8i = !p4hir.int<8>
-!int = !p4hir.infint
+!infint = !p4hir.infint
 
 #int0_b8i = #p4hir.int<0> : !b8i
 #int3_b8i = #p4hir.int<3> : !b8i
@@ -17,6 +17,17 @@
 #int-5_i8i = #p4hir.int<-5> : !i8i
 #int-40_i8i = #p4hir.int<-40> : !i8i
 
+#int0_infint = #p4hir.int<0> : !infint
+#int3_infint = #p4hir.int<3> : !infint
+#int5_infint = #p4hir.int<5> : !infint
+#int40_infint = #p4hir.int<40> : !infint
+#int62_infint = #p4hir.int<62> : !infint
+#int500_infint = #p4hir.int<500> : !infint
+#int128000_infint = #p4hir.int<128000> : !infint
+#int-5_infint = #p4hir.int<-5> : !infint
+#int-40_infint = #p4hir.int<-40> : !infint
+#int-62_infint = #p4hir.int<-62> : !infint
+#int-500_infint = #p4hir.int<-500> : !infint
 
 // CHECK: module
 module  {
@@ -30,6 +41,16 @@ module  {
   // CHECK-DAG: %[[cminus1_i8i:.*]] = p4hir.const #int-1_i8i
   // CHECK-DAG: %[[cminus5_i8i:.*]] = p4hir.const #int-5_i8i
   // CHECK-DAG: %[[cminus40_i8i:.*]] = p4hir.const #int-40_i8i
+  // CHECK-DAG: %[[c0_infint:.*]] = p4hir.const #int0_infint
+  // CHECK-DAG: %[[c5_infint:.*]] = p4hir.const #int5_infint
+  // CHECK-DAG: %[[c40_infint:.*]] = p4hir.const #int40_infint
+  // CHECK-DAG: %[[c62_infint:.*]] = p4hir.const #int62_infint
+  // CHECK-DAG: %[[c500_infint:.*]] = p4hir.const #int500_infint
+  // CHECK-DAG: %[[c128000_infint:.*]] = p4hir.const #int128000_infint
+  // CHECK-DAG: %[[cminus5_infint:.*]] = p4hir.const #int-5_infint
+  // CHECK-DAG: %[[cminus40_infint:.*]] = p4hir.const #int-40_infint
+  // CHECK-DAG: %[[cminus62_infint:.*]] = p4hir.const #int-62_infint
+  // CHECK-DAG: %[[cminus500_infint:.*]] = p4hir.const #int-500_infint
   %c0_b8i = p4hir.const #int0_b8i
   %c3_b8i = p4hir.const #int3_b8i
   %c5_b8i = p4hir.const #int5_b8i
@@ -37,18 +58,25 @@ module  {
   %c9_b8i = p4hir.const #int9_b8i
   %c40_b8i = p4hir.const #int40_b8i
   %c0_i8i = p4hir.const #int0_i8i
-  %c-1_i8i = p4hir.const #int-1_i8i
   %c-5_i8i = p4hir.const #int-5_i8i
   %c-40_i8i = p4hir.const #int-40_i8i
+  %c0_infint = p4hir.const #int0_infint
+  %c5_infint = p4hir.const #int5_infint
+  %c40_infint = p4hir.const #int40_infint
+  %c62_infint = p4hir.const #int62_infint
+  %c500_infint = p4hir.const #int500_infint
+  %c128000 = p4hir.const #int128000_infint
+  %c-5_infint = p4hir.const #int-5_infint
+  %c-40_infint = p4hir.const #int-40_infint
+  %c-62_infint = p4hir.const #int-62_infint
+  %c-500_infint = p4hir.const #int-500_infint
 
   p4hir.func @blackhole_b8i(!b8i)
   p4hir.func @blackhole_i8i(!i8i)
-  p4hir.func @blackhole_int(!int)
+  p4hir.func @blackhole_infint(!infint)
 
-  // CHECK-LABEL: p4hir.func @test_shift_zero_identity(%arg0: !b8i, %arg1: !i8i)
-  p4hir.func @test_shift_zero_identity(%arg_b8i : !b8i, %arg_i8i : !i8i) {
-    // ===== ShlOp =====
-
+  // CHECK-LABEL: p4hir.func @test_shift_zero_identity(%arg0: !b8i, %arg1: !i8i, %arg2: !infint)
+  p4hir.func @test_shift_zero_identity(%arg_b8i : !b8i, %arg_i8i : !i8i, %arg_infint : !infint) {
     // CHECK: p4hir.call @blackhole_b8i (%arg0) : (!b8i) -> ()
     %shl0 = p4hir.shl(%arg_b8i, %c0_b8i : !b8i) : !b8i
     p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
@@ -57,7 +85,10 @@ module  {
     %shl1 = p4hir.shl(%c8_b8i, %c0_b8i : !b8i) : !b8i
     p4hir.call @blackhole_b8i(%shl1) : (!b8i) -> ()
 
-    // ===== ShrOp =====
+    // CHECK: p4hir.call @blackhole_infint (%arg2) : (!infint) -> ()
+    %shl2 = p4hir.shl(%arg_infint, %c0_b8i : !b8i) : !infint
+    p4hir.call @blackhole_infint(%shl2) : (!infint) -> ()
+
 
     // CHECK: p4hir.call @blackhole_b8i (%arg0) : (!b8i) -> ()
     %shr0 = p4hir.shr(%arg_b8i, %c0_b8i : !b8i) : !b8i
@@ -66,14 +97,16 @@ module  {
     // CHECK: p4hir.call @blackhole_i8i (%arg1) : (!i8i) -> ()
     %shr1 = p4hir.shr(%arg_i8i, %c0_b8i : !b8i) : !i8i
     p4hir.call @blackhole_i8i(%shr1) : (!i8i) -> ()
+   
+    // CHECK: p4hir.call @blackhole_infint (%arg2) : (!infint) -> ()
+    %shr2 = p4hir.shr(%arg_infint, %c0_b8i : !b8i) : !infint
+    p4hir.call @blackhole_infint(%shr2) : (!infint) -> ()
 
     p4hir.return
   }
 
   // CHECK-LABEL: p4hir.func @test_shift_ge_width(%arg0: !b8i, %arg1: !i8i)
   p4hir.func @test_shift_ge_width(%arg_b8i : !b8i, %arg_i8i : !i8i) {
-    // ===== ShlOp =====
-
     // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
     %shl0 = p4hir.shl(%arg_b8i, %c9_b8i : !b8i) : !b8i
     p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
@@ -82,7 +115,6 @@ module  {
     %shl1 = p4hir.shl(%arg_i8i, %c8_b8i : !b8i) : !i8i
     p4hir.call @blackhole_i8i(%shl1) : (!i8i) -> ()
 
-    // ===== ShrOp =====
 
     // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
     %shr0 = p4hir.shr(%arg_b8i, %c8_b8i : !b8i) : !b8i
@@ -103,8 +135,6 @@ module  {
 
   // CHECK-LABEL: p4hir.func @test_shift_const()
   p4hir.func @test_shift_const() {
-    // ===== ShlOp =====
-
     // CHECK: p4hir.call @blackhole_b8i (%[[c40_b8i]]) : (!b8i) -> ()
     %shl0 = p4hir.shl(%c5_b8i, %c3_b8i : !b8i) : !b8i // 5 << 3 = 40
     p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
@@ -112,8 +142,6 @@ module  {
     // CHECK: p4hir.call @blackhole_i8i (%[[cminus40_i8i]]) : (!i8i) -> ()
     %shl1 = p4hir.shl(%c-5_i8i, %c3_b8i : !b8i) : !i8i // -5 << 3 = -40
     p4hir.call @blackhole_i8i(%shl1) : (!i8i) -> ()
-
-    // ===== ShrOp =====
 
     // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
     %shr0 = p4hir.shr(%c5_b8i, %c3_b8i : !b8i) : !b8i // 5 >> 3 (logical) = 0
@@ -126,10 +154,52 @@ module  {
     p4hir.return
   }
 
-  // Ensure these constants stay in the module
+  // CHECK-LABEL: p4hir.func @test_shift_infint()
+  p4hir.func @test_shift_infint() {
+    // CHECK: p4hir.call @blackhole_infint (%[[c40_infint]]) : (!infint) -> ()
+    %shl0 = p4hir.shl(%c5_infint, %c3_b8i : !b8i) : !infint // 5 << 3 = 40
+    p4hir.call @blackhole_infint(%shl0) : (!infint) -> ()
+
+    // CHECK: p4hir.call @blackhole_infint (%[[cminus40_infint]]) : (!infint) -> ()
+    %shl1 = p4hir.shl(%c-5_infint, %c3_b8i : !b8i) : !infint // -5 << 3 = -40
+    p4hir.call @blackhole_infint(%shl1) : (!infint) -> ()
+
+    // CHECK: p4hir.call @blackhole_infint (%[[c128000_infint]]) : (!infint) -> ()
+    %shl2 = p4hir.shl(%c500_infint, %c8_b8i : !b8i) : !infint // 500 << 8 = 128000
+    p4hir.call @blackhole_infint(%shl2) : (!infint) -> ()
+
+
+    // CHECK: p4hir.call @blackhole_infint (%[[c0_infint]]) : (!infint) -> ()
+    %shr0 = p4hir.shr(%c5_infint, %c3_b8i : !b8i) : !infint // 5 >> 3 = 0
+    p4hir.call @blackhole_infint(%shr0) : (!infint) -> ()
+
+    // NOTE: -5 >> 3 = -1, but -5 / (2 ^ 3) = 0
+    // CHECK: p4hir.call @blackhole_infint (%[[c0_infint]]) : (!infint) -> ()
+    %shr1 = p4hir.shr(%c-5_infint, %c3_b8i : !b8i) : !infint
+    p4hir.call @blackhole_infint(%shr1) : (!infint) -> ()
+
+    // CHECK: p4hir.call @blackhole_infint (%[[c62_infint]]) : (!infint) -> ()
+    %shr2 = p4hir.shr(%c500_infint, %c3_b8i : !b8i) : !infint // 500 >> 3 = 62
+    p4hir.call @blackhole_infint(%shr2) : (!infint) -> ()
+
+    // NOTE: -500 >> 3 = -63, but -500 / (2 ^ 3) = -62
+    // CHECK: p4hir.call @blackhole_infint (%[[cminus62_infint]]) : (!infint) -> ()
+    %shr3 = p4hir.shr(%c-500_infint, %c3_b8i : !b8i) : !infint
+    p4hir.call @blackhole_infint(%shr3) : (!infint) -> ()
+
+    p4hir.return
+  }
+
+  // Make sure these constants don't get DCE'd
   p4hir.call @blackhole_b8i(%c3_b8i) : (!b8i) -> ()
   p4hir.call @blackhole_b8i(%c5_b8i) : (!b8i) -> ()
   p4hir.call @blackhole_i8i(%c-5_i8i) : (!i8i) -> ()
   p4hir.call @blackhole_i8i(%c-40_i8i) : (!i8i) -> ()
+  p4hir.call @blackhole_infint(%c0_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c5_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c500_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c-40_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c-5_infint) : (!infint) -> ()
+  p4hir.call @blackhole_infint(%c-500_infint) : (!infint) -> ()
 }
 

--- a/test/Transforms/Folds/shl_shr.mlir
+++ b/test/Transforms/Folds/shl_shr.mlir
@@ -1,0 +1,40 @@
+// RUN: p4mlir-opt --canonicalize %s | FileCheck %s
+
+!b8i = !p4hir.bit<8>
+!i8i = !p4hir.int<8>
+!int  = !p4hir.infint
+
+#int0_b8i = #p4hir.int<0> : !b8i
+#int9_b8i = #p4hir.int<9> : !b8i
+
+// CHECK: module
+module  {
+  // CHECK: %[[c0:.*]] = p4hir.const #int0_b8i
+  %c0 = p4hir.const #int0_b8i
+
+  p4hir.func @blackhole_b8i(!b8i)
+  p4hir.func @blackhole_i8i(!i8i)
+  p4hir.func @blackhole_int(!int)
+
+  // CHECK-LABEL: p4hir.func @test_shift_zero(%arg0: !b8i)
+  p4hir.func @test_shift_zero(%arg_b8 : !b8i) {
+    // CHECK: p4hir.call @blackhole_b8i (%arg0) : (!b8i) -> ()
+    %shl0 = p4hir.shl(%arg_b8, %c0 : !b8i) : !b8i
+    p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
+
+    p4hir.return
+  }
+
+  // CHECK-LABEL: p4hir.func @test_shift_width(%arg0: !b8i)
+  p4hir.func @test_shift_width(%arg_b8 : !b8i) {
+    %c9 = p4hir.const #int9_b8i
+
+    // CHECK: p4hir.call @blackhole_b8i (%[[c0]]) : (!b8i) -> ()
+    %shl0 = p4hir.shl(%arg_b8, %c9 : !b8i) : !b8i
+    p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
+
+    p4hir.return
+
+  }
+}
+

--- a/test/Transforms/Folds/shl_shr.mlir
+++ b/test/Transforms/Folds/shl_shr.mlir
@@ -1,40 +1,135 @@
 // RUN: p4mlir-opt --canonicalize %s | FileCheck %s
 
+!b4i = !p4hir.bit<4>
 !b8i = !p4hir.bit<8>
 !i8i = !p4hir.int<8>
-!int  = !p4hir.infint
+!int = !p4hir.infint
 
 #int0_b8i = #p4hir.int<0> : !b8i
+#int3_b8i = #p4hir.int<3> : !b8i
+#int5_b8i = #p4hir.int<5> : !b8i
+#int8_b8i = #p4hir.int<8> : !b8i
 #int9_b8i = #p4hir.int<9> : !b8i
+#int40_b8i = #p4hir.int<40> : !b8i
+
+#int0_i8i = #p4hir.int<0> : !i8i
+#int-1_i8i = #p4hir.int<-1> : !i8i
+#int-5_i8i = #p4hir.int<-5> : !i8i
+#int-40_i8i = #p4hir.int<-40> : !i8i
+
 
 // CHECK: module
 module  {
-  // CHECK: %[[c0:.*]] = p4hir.const #int0_b8i
-  %c0 = p4hir.const #int0_b8i
+  // CHECK-DAG: %[[c0_b8i:.*]] = p4hir.const #int0_b8i
+  // CHECK-DAG: %[[c3_b8i:.*]] = p4hir.const #int3_b8i
+  // CHECK-DAG: %[[c5_b8i:.*]] = p4hir.const #int5_b8i
+  // CHECK-DAG: %[[c8_b8i:.*]] = p4hir.const #int8_b8i
+  // CHECK-DAG: %[[c9_b8i:.*]] = p4hir.const #int9_b8i
+  // CHECK-DAG: %[[c40_b8i:.*]] = p4hir.const #int40_b8i
+  // CHECK-DAG: %[[c0_i8i:.*]] = p4hir.const #int0_i8i
+  // CHECK-DAG: %[[cminus1_i8i:.*]] = p4hir.const #int-1_i8i
+  // CHECK-DAG: %[[cminus5_i8i:.*]] = p4hir.const #int-5_i8i
+  // CHECK-DAG: %[[cminus40_i8i:.*]] = p4hir.const #int-40_i8i
+  %c0_b8i = p4hir.const #int0_b8i
+  %c3_b8i = p4hir.const #int3_b8i
+  %c5_b8i = p4hir.const #int5_b8i
+  %c8_b8i = p4hir.const #int8_b8i
+  %c9_b8i = p4hir.const #int9_b8i
+  %c40_b8i = p4hir.const #int40_b8i
+  %c0_i8i = p4hir.const #int0_i8i
+  %c-1_i8i = p4hir.const #int-1_i8i
+  %c-5_i8i = p4hir.const #int-5_i8i
+  %c-40_i8i = p4hir.const #int-40_i8i
 
   p4hir.func @blackhole_b8i(!b8i)
   p4hir.func @blackhole_i8i(!i8i)
   p4hir.func @blackhole_int(!int)
 
-  // CHECK-LABEL: p4hir.func @test_shift_zero(%arg0: !b8i)
-  p4hir.func @test_shift_zero(%arg_b8 : !b8i) {
+  // CHECK-LABEL: p4hir.func @test_shift_zero_identity(%arg0: !b8i, %arg1: !i8i)
+  p4hir.func @test_shift_zero_identity(%arg_b8i : !b8i, %arg_i8i : !i8i) {
+    // ===== ShlOp =====
+
     // CHECK: p4hir.call @blackhole_b8i (%arg0) : (!b8i) -> ()
-    %shl0 = p4hir.shl(%arg_b8, %c0 : !b8i) : !b8i
+    %shl0 = p4hir.shl(%arg_b8i, %c0_b8i : !b8i) : !b8i
     p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b8i (%[[c8_b8i]]) : (!b8i) -> ()
+    %shl1 = p4hir.shl(%c8_b8i, %c0_b8i : !b8i) : !b8i
+    p4hir.call @blackhole_b8i(%shl1) : (!b8i) -> ()
+
+    // ===== ShrOp =====
+
+    // CHECK: p4hir.call @blackhole_b8i (%arg0) : (!b8i) -> ()
+    %shr0 = p4hir.shr(%arg_b8i, %c0_b8i : !b8i) : !b8i
+    p4hir.call @blackhole_b8i(%shr0) : (!b8i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i8i (%arg1) : (!i8i) -> ()
+    %shr1 = p4hir.shr(%arg_i8i, %c0_b8i : !b8i) : !i8i
+    p4hir.call @blackhole_i8i(%shr1) : (!i8i) -> ()
 
     p4hir.return
   }
 
-  // CHECK-LABEL: p4hir.func @test_shift_width(%arg0: !b8i)
-  p4hir.func @test_shift_width(%arg_b8 : !b8i) {
-    %c9 = p4hir.const #int9_b8i
+  // CHECK-LABEL: p4hir.func @test_shift_ge_width(%arg0: !b8i, %arg1: !i8i)
+  p4hir.func @test_shift_ge_width(%arg_b8i : !b8i, %arg_i8i : !i8i) {
+    // ===== ShlOp =====
 
-    // CHECK: p4hir.call @blackhole_b8i (%[[c0]]) : (!b8i) -> ()
-    %shl0 = p4hir.shl(%arg_b8, %c9 : !b8i) : !b8i
+    // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
+    %shl0 = p4hir.shl(%arg_b8i, %c9_b8i : !b8i) : !b8i
     p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
 
-    p4hir.return
+    // CHECK: p4hir.call @blackhole_i8i (%[[c0_i8i]]) : (!i8i) -> ()
+    %shl1 = p4hir.shl(%arg_i8i, %c8_b8i : !b8i) : !i8i
+    p4hir.call @blackhole_i8i(%shl1) : (!i8i) -> ()
 
+    // ===== ShrOp =====
+
+    // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
+    %shr0 = p4hir.shr(%arg_b8i, %c8_b8i : !b8i) : !b8i
+    p4hir.call @blackhole_b8i(%shr0) : (!b8i) -> ()
+
+    // CHECK: %[[shr:.*]] = p4hir.shr(%arg1, %[[c9_b8i]] : !b8i) : !i8i
+    // CHECK: p4hir.call @blackhole_i8i (%[[shr]]) : (!i8i) -> ()
+    %shr1 = p4hir.shr(%arg_i8i, %c9_b8i : !b8i) : !i8i // arg >> 9 = no fold (signed var)
+    p4hir.call @blackhole_i8i(%shr1) : (!i8i) -> ()
+
+    // 0b11111111 = -1
+    // CHECK: p4hir.call @blackhole_i8i (%[[cminus1_i8i]]) : (!i8i) -> ()
+    %shr2 = p4hir.shr(%c-5_i8i, %c9_b8i : !b8i) : !i8i
+    p4hir.call @blackhole_i8i(%shr2) : (!i8i) -> ()
+
+    p4hir.return
   }
+
+  // CHECK-LABEL: p4hir.func @test_shift_const()
+  p4hir.func @test_shift_const() {
+    // ===== ShlOp =====
+
+    // CHECK: p4hir.call @blackhole_b8i (%[[c40_b8i]]) : (!b8i) -> ()
+    %shl0 = p4hir.shl(%c5_b8i, %c3_b8i : !b8i) : !b8i // 5 << 3 = 40
+    p4hir.call @blackhole_b8i(%shl0) : (!b8i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i8i (%[[cminus40_i8i]]) : (!i8i) -> ()
+    %shl1 = p4hir.shl(%c-5_i8i, %c3_b8i : !b8i) : !i8i // -5 << 3 = -40
+    p4hir.call @blackhole_i8i(%shl1) : (!i8i) -> ()
+
+    // ===== ShrOp =====
+
+    // CHECK: p4hir.call @blackhole_b8i (%[[c0_b8i]]) : (!b8i) -> ()
+    %shr0 = p4hir.shr(%c5_b8i, %c3_b8i : !b8i) : !b8i // 5 >> 3 (logical) = 0
+    p4hir.call @blackhole_b8i(%shr0) : (!b8i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i8i (%[[cminus1_i8i]]) : (!i8i) -> ()
+    %shr1 = p4hir.shr(%c-5_i8i, %c3_b8i : !b8i) : !i8i // -5 >> 3 (arith) = -1
+    p4hir.call @blackhole_i8i(%shr1) : (!i8i) -> ()
+
+    p4hir.return
+  }
+
+  // Ensure these constants stay in the module
+  p4hir.call @blackhole_b8i(%c3_b8i) : (!b8i) -> ()
+  p4hir.call @blackhole_b8i(%c5_b8i) : (!b8i) -> ()
+  p4hir.call @blackhole_i8i(%c-5_i8i) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%c-40_i8i) : (!i8i) -> ()
 }
 

--- a/test/Transforms/Folds/unary.mlir
+++ b/test/Transforms/Folds/unary.mlir
@@ -1,58 +1,68 @@
 // RUN: p4mlir-opt --canonicalize %s | FileCheck %s
 
-!b8 = !p4hir.bit<8>
+!b8i = !p4hir.bit<8>
 !b  = !p4hir.bool
 
-#int5_b8 = #p4hir.int<5> : !b8
-#true_b = #p4hir.bool<true> : !b
-#false_b = #p4hir.bool<false> : !b
+#int5_b8i = #p4hir.int<5> : !b8i
+#int-5_b8i = #p4hir.int<-5> : !b8i
+#int-6_b8i = #p4hir.int<-6> : !b8i
+#true = #p4hir.bool<true> : !b
+#false = #p4hir.bool<false> : !b
 
+// CHECK-LABEL: module
 module {
-  p4hir.func @blackhole(!b8)
+
+  // CHECK: %[[true:.*]] = p4hir.const #true
+  // CHECK: %[[false:.*]] = p4hir.const #false
+  // CHECK: %[[cminus6:.*]] = p4hir.const #int-6_b8i
+  // CHECK: %[[cminus5:.*]] = p4hir.const #int-5_b8i
+  // CHECK: %[[c5:.*]] = p4hir.const #int5_b8i
+  %true = p4hir.const #true
+  %false = p4hir.const #false
+  %c-6 = p4hir.const #int-6_b8i
+  %c-5 = p4hir.const #int-5_b8i
+  %c5 = p4hir.const #int5_b8i
+
+  p4hir.func @blackhole(!b8i)
   p4hir.func @blackhole_bool(!b)
 
   // CHECK-LABEL: p4hir.func @test_unary_const
   p4hir.func @test_unary_const() {
-    // CHECK: p4hir.call @blackhole (%{{.*}}-5{{.*}}) : (!b8i) -> ()
-    %c1 = p4hir.const #int5_b8
-    %r1 = p4hir.unary(minus, %c1) : !b8
-    p4hir.call @blackhole(%r1) : (!b8) -> ()
+    // CHECK: p4hir.call @blackhole (%[[cminus5]]) : (!b8i) -> ()
+    %r1 = p4hir.unary(minus, %c5) : !b8i
+    p4hir.call @blackhole(%r1) : (!b8i) -> ()
 
-    // CHECK: p4hir.call @blackhole (%{{.*}}5{{.*}}) : (!b8i) -> ()
-    %c2 = p4hir.const #int5_b8
-    %r2 = p4hir.unary(plus, %c2) : !b8
-    p4hir.call @blackhole(%r2) : (!b8) -> ()
+    // CHECK: p4hir.call @blackhole (%[[c5]]) : (!b8i) -> ()
+    %r2 = p4hir.unary(plus, %c5) : !b8i
+    p4hir.call @blackhole(%r2) : (!b8i) -> ()
 
     // ~5 = -6
-    // CHECK: p4hir.call @blackhole (%{{.*}}-6{{.*}}) : (!b8i) -> ()
-    %c3 = p4hir.const #int5_b8
-    %r3 = p4hir.unary(cmpl, %c3) : !b8
-    p4hir.call @blackhole(%r3) : (!b8) -> ()
+    // CHECK: p4hir.call @blackhole (%[[cminus6]]) : (!b8i) -> ()
+    %r3 = p4hir.unary(cmpl, %c5) : !b8i
+    p4hir.call @blackhole(%r3) : (!b8i) -> ()
 
-    // CHECK: p4hir.call @blackhole_bool (%{{.*}}false{{.*}}) : (!p4hir.bool) -> ()
-    %c4 = p4hir.const #true_b
-    %r4 = p4hir.unary(not, %c4) : !b
+    // CHECK: p4hir.call @blackhole_bool (%[[false]]) : (!p4hir.bool) -> ()
+    %r4 = p4hir.unary(not, %true) : !b
     p4hir.call @blackhole_bool(%r4) : (!b) -> ()
 
-    // CHECK: p4hir.call @blackhole_bool (%{{.*}}true{{.*}}) : (!p4hir.bool) -> ()
-    %c5 = p4hir.const #false_b
-    %r5 = p4hir.unary(not, %c5) : !b
+    // CHECK: p4hir.call @blackhole_bool (%[[true]]) : (!p4hir.bool) -> ()
+    %r5 = p4hir.unary(not, %false) : !b
     p4hir.call @blackhole_bool(%r5) : (!b) -> ()
 
     p4hir.return
   }
 
   // CHECK-LABEL: p4hir.func @test_unary(%arg0: !b8i, %arg1: !p4hir.bool)
-  p4hir.func @test_unary(%arg_b8 : !b8, %arg_b : !b) {
+  p4hir.func @test_unary(%arg_b8i : !b8i, %arg_b : !b) {
     // CHECK: p4hir.call @blackhole (%arg0)
-    %m1 = p4hir.unary(minus, %arg_b8) : !b8
-    %m2 = p4hir.unary(minus, %m1) : !b8
-    p4hir.call @blackhole(%m2) : (!b8) -> ()
+    %m1 = p4hir.unary(minus, %arg_b8i) : !b8i
+    %m2 = p4hir.unary(minus, %m1) : !b8i
+    p4hir.call @blackhole(%m2) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole (%arg0)
-    %c1 = p4hir.unary(cmpl, %arg_b8) : !b8
-    %c2 = p4hir.unary(cmpl, %c1) : !b8
-    p4hir.call @blackhole(%c2) : (!b8) -> ()
+    %c1 = p4hir.unary(cmpl, %arg_b8i) : !b8i
+    %c2 = p4hir.unary(cmpl, %c1) : !b8i
+    p4hir.call @blackhole(%c2) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole_bool (%arg1)
     %n1 = p4hir.unary(not, %arg_b) : !b
@@ -60,13 +70,13 @@ module {
     p4hir.call @blackhole_bool(%n2) : (!b) -> ()
 
     // CHECK: p4hir.call @blackhole (%arg0)
-    %p1 = p4hir.unary(plus, %arg_b8) : !b8
-    p4hir.call @blackhole(%p1) : (!b8) -> ()
+    %p1 = p4hir.unary(plus, %arg_b8i) : !b8i
+    p4hir.call @blackhole(%p1) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole (%arg0)
-    %p2 = p4hir.unary(plus, %arg_b8) : !b8
-    %p3 = p4hir.unary(plus, %p2) : !b8
-    p4hir.call @blackhole(%p3) : (!b8) -> ()
+    %p2 = p4hir.unary(plus, %arg_b8i) : !b8i
+    %p3 = p4hir.unary(plus, %p2) : !b8i
+    p4hir.call @blackhole(%p3) : (!b8i) -> ()
 
     p4hir.return
   }

--- a/test/Transforms/Folds/unary.mlir
+++ b/test/Transforms/Folds/unary.mlir
@@ -11,34 +11,33 @@
 
 // CHECK-LABEL: module
 module {
-
-  // CHECK: %[[true:.*]] = p4hir.const #true
-  // CHECK: %[[false:.*]] = p4hir.const #false
-  // CHECK: %[[cminus6:.*]] = p4hir.const #int-6_b8i
-  // CHECK: %[[cminus5:.*]] = p4hir.const #int-5_b8i
-  // CHECK: %[[c5:.*]] = p4hir.const #int5_b8i
+  // CHECK-DAG: %[[true:.*]] = p4hir.const #true
+  // CHECK-DAG: %[[false:.*]] = p4hir.const #false
+  // CHECK-DAG: %[[cminus6_b8i:.*]] = p4hir.const #int-6_b8i
+  // CHECK-DAG: %[[cminus5_b8i:.*]] = p4hir.const #int-5_b8i
+  // CHECK-DAG: %[[c5:.*]] = p4hir.const #int5_b8i
   %true = p4hir.const #true
   %false = p4hir.const #false
-  %c-6 = p4hir.const #int-6_b8i
-  %c-5 = p4hir.const #int-5_b8i
-  %c5 = p4hir.const #int5_b8i
+  %c-6_b8i = p4hir.const #int-6_b8i
+  %c-5_b8i = p4hir.const #int-5_b8i
+  %c5_b8i = p4hir.const #int5_b8i
 
   p4hir.func @blackhole(!b8i)
   p4hir.func @blackhole_bool(!b)
 
   // CHECK-LABEL: p4hir.func @test_unary_const
   p4hir.func @test_unary_const() {
-    // CHECK: p4hir.call @blackhole (%[[cminus5]]) : (!b8i) -> ()
-    %r1 = p4hir.unary(minus, %c5) : !b8i
+    // CHECK: p4hir.call @blackhole (%[[cminus5_b8i]]) : (!b8i) -> ()
+    %r1 = p4hir.unary(minus, %c5_b8i) : !b8i
     p4hir.call @blackhole(%r1) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole (%[[c5]]) : (!b8i) -> ()
-    %r2 = p4hir.unary(plus, %c5) : !b8i
+    %r2 = p4hir.unary(plus, %c5_b8i) : !b8i
     p4hir.call @blackhole(%r2) : (!b8i) -> ()
 
     // ~5 = -6
-    // CHECK: p4hir.call @blackhole (%[[cminus6]]) : (!b8i) -> ()
-    %r3 = p4hir.unary(cmpl, %c5) : !b8i
+    // CHECK: p4hir.call @blackhole (%[[cminus6_b8i]]) : (!b8i) -> ()
+    %r3 = p4hir.unary(cmpl, %c5_b8i) : !b8i
     p4hir.call @blackhole(%r3) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole_bool (%[[false]]) : (!p4hir.bool) -> ()
@@ -60,9 +59,9 @@ module {
     p4hir.call @blackhole(%m2) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole (%arg0)
-    %c1 = p4hir.unary(cmpl, %arg_b8i) : !b8i
-    %c2 = p4hir.unary(cmpl, %c1) : !b8i
-    p4hir.call @blackhole(%c2) : (!b8i) -> ()
+    %c1_b8i = p4hir.unary(cmpl, %arg_b8i) : !b8i
+    %c2_b8i = p4hir.unary(cmpl, %c1_b8i) : !b8i
+    p4hir.call @blackhole(%c2_b8i) : (!b8i) -> ()
 
     // CHECK: p4hir.call @blackhole_bool (%arg1)
     %n1 = p4hir.unary(not, %arg_b) : !b


### PR DESCRIPTION
I renamed `verifyArithmeticShiftOperation()` -> `verifyShiftOperation()` as well as the corresponding `OpError` message because, from my understanding from the spec, logical and arithmetic shifts depend on whether the left operand's type is signed or unsigned, and since we check this for unsigned integers as well the error shouldn't specify "arithmetic shift" (?)

Also question: can we fold `InfIntType` shifts? I initially was going to handle constant `InfIntType` lhs values by applying the formula from the spec:

> The expression `a << b` is equal to `a x 2^b` while `a >> b` is equal to `a / 2^b`

But I saw that for example [CastOp::fold()](https://github.com/p4lang/p4mlir-incubator/blob/80e796ce6bac2045941eb1ef6285ff7a13e3052f/lib/Dialect/P4HIR/P4HIR_Ops.cpp#L170) only folds if the destination type is a fixed-width integer. Is that just a `TODO` or are there limitations on folding `InfIntType`s? I'm guessing the latter but wanted to confirm just in case, Thanks!