### PR TITLE
Update P4C reference and add some linter configurations. Compile with DebugInfo.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks:
+'clang-diagnostic-*,
+clang-analyzer-*,
+modernize-*,
+performance-*,
+readability-*,
+bugprone-*,
+cppcoreguidelines-*,
+boost-*,
+hicpp-*,
+misc-*,
+llvm-*,
+google-*,
+-modernize-use-trailing-return-type,
+-misc-confusable-identifiers,
+-readability-identifier-length,
+-cppcoreguidelines-owning-memory,
+-bugprone-easily-swappable-parameters,
+-llvm-header-guard,
+-llvm-include-order,
+-misc-no-recursion'
+FormatStyle: file
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+UseColor: true
+...

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: third_party/p4c/build/

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+third_party/p4c/CPPLINT.cfg

--- a/build_tools/build_p4c_with_p4mlir_ext.sh
+++ b/build_tools/build_p4c_with_p4mlir_ext.sh
@@ -32,6 +32,7 @@ fi
 # Configure CMake flags
 CMAKE_FLAGS="-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER:-clang}"
 CMAKE_FLAGS+=" -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER:-clang++}"
+CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
 # Configure P4C CMake flags
 # https://github.com/p4lang/p4c/blob/main/CMakeLists.txt


### PR DESCRIPTION
Recent P4C updates include some cpplint updates which can also be useful here. Also add some more configurations specific to this repository. The `.clang-tidy` file could also be a symlink. 