### PR TITLE
Allow nameless (anonymous) enums

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -580,9 +580,21 @@ def EnumType : P4HIR_Type<"Enum", "enum", []> {
                    annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
     }]>,
 
+     TypeBuilder<(ins "llvm::ArrayRef<mlir::Attribute>":$fields,
+                     CArg<"mlir::DictionaryAttr", "{}">:$annotations), [{
+      return $_get($_ctxt, "", mlir::ArrayAttr::get($_ctxt, fields),
+                   annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
+    }]>,
+
     TypeBuilder<(ins "llvm::StringRef":$name, "mlir::ArrayAttr":$fields,
                      CArg<"mlir::DictionaryAttr", "{}">:$annotations), [{
       return $_get($_ctxt, name, fields,
+                   annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
+    }]>,
+
+    TypeBuilder<(ins "mlir::ArrayAttr":$fields,
+                     CArg<"mlir::DictionaryAttr", "{}">:$annotations), [{
+      return $_get($_ctxt, "", fields,
                    annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
     }]>,
   ];

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -2954,7 +2954,8 @@ struct P4HIROpAsmDialectInterface : public OpAsmDialectInterface {
         }
 
         if (auto enumType = mlir::dyn_cast<P4HIR::EnumType>(type)) {
-            os << enumType.getName();
+            auto name = enumType.getName();
+            os << (name.empty() ? "anon" : name);
             return AliasResult::OverridableAlias;
         }
 
@@ -3072,7 +3073,8 @@ struct P4HIROpAsmDialectInterface : public OpAsmDialectInterface {
 
         if (auto enumFieldAttr = mlir::dyn_cast<P4HIR::EnumFieldAttr>(attr)) {
             if (auto enumType = mlir::dyn_cast<P4HIR::EnumType>(enumFieldAttr.getType()))
-                os << enumType.getName() << "_" << enumFieldAttr.getField().getValue();
+                os << (enumType.getName().empty() ? "anon" : enumType.getName()) << "_"
+                   << enumFieldAttr.getField().getValue();
             else
                 os << mlir::cast<P4HIR::SerEnumType>(enumFieldAttr.getType()).getName() << "_"
                    << enumFieldAttr.getField().getValue();

--- a/test/Dialect/P4HIR/annotations.mlir
+++ b/test/Dialect/P4HIR/annotations.mlir
@@ -22,6 +22,8 @@
 #int42_infint = #p4hir.int<42> : !infint
 !Foo = !p4hir.struct<"Foo", bar: !b32i {match = #ternary}>
 !SomeEnum = !p4hir.enum<"SomeEnum" {p4runtime_translation = ["p4.org/psa/v1/bar", ",", "enum"]}, Field, Field2>
+!AnonEnum = !p4hir.enum<{p4runtime_translation = ["p4.org/psa/v1/bar", ",", "enum"]}, Field, Field2>
+#AnonEnum_Field = #p4hir.enum_field<Field, !AnonEnum> : !AnonEnum
 !b9i = !p4hir.bit<9>
 !validity_bit = !p4hir.validity.bit
 !PortId_32_t = !p4hir.alias<"PortId_32_t" annotations {p4runtime_translation = ["p4.org/psa/v1/PortId_32_t", ",", "32"]}, !b9i>
@@ -128,7 +130,7 @@ module {
     }
   }
 
-  p4hir.func action @foo(%arg0: !Meta {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "m"}, %arg1: !packet_in_header_t {p4hir.annotations = {optional}, p4hir.dir = #p4hir<dir in>, p4hir.param_name = "hdr"}, %arg2: !SomeEnum {p4hir.dir = #p4hir<dir undir>, p4hir.param_name = "e"}) {
+  p4hir.func action @foo(%arg0: !Meta {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "m"}, %arg1: !packet_in_header_t {p4hir.annotations = {optional}, p4hir.dir = #p4hir<dir in>, p4hir.param_name = "hdr"}, %arg2: !SomeEnum {p4hir.dir = #p4hir<dir undir>, p4hir.param_name = "e"}, %arg3: !AnonEnum {p4hir.dir = #p4hir<dir undir>, p4hir.param_name = "f"}) {
     p4hir.return
   }
 }

--- a/test/Dialect/P4HIR/enum.mlir
+++ b/test/Dialect/P4HIR/enum.mlir
@@ -1,9 +1,12 @@
-// RUN: p4mlir-opt %s | FileCheck %s
+// RUN: p4mlir-opt --verify-roundtrip %s | FileCheck %s
 
 !Suits = !p4hir.enum<"Suits", Clubs, Diamonds, Hearths, Spades>
 
 #Suits_Clubs = #p4hir.enum_field<Clubs, !Suits> : !Suits
 #Suits_Diamonds = #p4hir.enum_field<Diamonds, !Suits> : !Suits
+
+!anon = !p4hir.enum<Foo, Bar, Baz>
+#anon_Foo = #p4hir.enum_field<Foo, !anon> : !anon
 
 // CHECK: module
 module {

--- a/test/Dialect/P4HIR/table.mlir
+++ b/test/Dialect/P4HIR/table.mlir
@@ -1,8 +1,8 @@
 // RUN: p4mlir-opt --verify-roundtrip %s | FileCheck %s
 
 !ActionProfile = !p4hir.extern<"ActionProfile">
-!action_enum = !p4hir.enum<"action_enum", a, b>
-!action_enum1 = !p4hir.enum<"action_enum", a, b, aa>
+!action_enum = !p4hir.enum<a, b>
+!action_enum1 = !p4hir.enum<a, b, aa>
 !b32i = !p4hir.bit<32>
 !i8i = !p4hir.int<8>
 !infint = !p4hir.infint

--- a/test/Translate/Ops/switch-action-run.p4
+++ b/test/Translate/Ops/switch-action-run.p4
@@ -1,5 +1,7 @@
 // RUN: p4mlir-translate --typeinference-only %s | FileCheck %s
 
+// CHECK: ![[action_enum:.*]] = !p4hir.enum<a, b>
+// CHECK: #[[action_enum_b:.*]] = #p4hir.enum_field<b, ![[action_enum]]> : ![[action_enum]]
 // CHECK-LABEL: p4hir.control @ctrl
 control ctrl() {
     action a() {}
@@ -14,8 +16,8 @@ control ctrl() {
 // CHECK:  p4hir.control_apply
 // CHECK:      %[[t_apply_result:.*]] = p4hir.table_apply @t : !t
 // CHECK:      %[[action_run:.*]] = p4hir.struct_extract %[[t_apply_result]]["action_run"] : !t
-// CHECK:      p4hir.switch (%[[action_run]] : !action_enum)
-// CHECK:        p4hir.case(equal, [#action_enum_b])
+// CHECK:      p4hir.switch (%[[action_run]] : ![[action_enum]])
+// CHECK:        p4hir.case(equal, [#[[action_enum_b]]])
         switch (t.apply().action_run) {
             b: { exit; }
             default: { return; }

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -1045,7 +1045,7 @@ bool P4TypeConverter::preorder(const P4::IR::Type_ActionEnum *type) {
         cases.push_back(
             mlir::StringAttr::get(converter.context(), action->getName().string_view()));
     }
-    auto mlirType = P4HIR::EnumType::get(converter.context(), "action_enum", cases);
+    auto mlirType = P4HIR::EnumType::get(converter.context(), cases);
     return setType(type, mlirType);
 }
 


### PR DESCRIPTION
These are used to represent action enums, where we really do not care about name, but only need the list of fields (also preventing clashes with user-provided enums in theory).

Fixes #174 