### PR TITLE
Implement select cases simplifications (#204)

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.h
@@ -5,8 +5,16 @@
 // order to propagate pragma further on
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
+#include <optional>
+
+#include "llvm/ADT/APSInt.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Types.h"
+
+namespace P4::P4MLIR::P4HIR {
+std::optional<llvm::APSInt> getConstantInt(mlir::Attribute attr);
+mlir::TypedAttr foldConstantCast(mlir::Type destType, mlir::Attribute srcAttr);
+}  // namespace  P4::P4MLIR::P4HIR
 
 namespace P4::P4MLIR::P4HIR::detail {
 struct IntAttrStorage : public ::mlir::AttributeStorage {

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.td
@@ -275,21 +275,19 @@ def P4HIR_UniversalSetAttr : P4HIR_Attr<"UniversalSet", "universal_set", [TypedA
 def SetKind_Const : I32EnumAttrCase<"Constant", 1, "const">;
 def SetKind_Range : I32EnumAttrCase<"Range", 2, "range">;
 def SetKind_Mask  : I32EnumAttrCase<"Mask", 3, "mask">;
-def SetKind_Prod  : I32EnumAttrCase<"Prod", 4, "prod">;
 
 def SetKind : I32EnumAttr<
     "SetKind",
     "set constant kind",
-    [SetKind_Const, SetKind_Range, SetKind_Mask, SetKind_Prod]> {
+    [SetKind_Const, SetKind_Range, SetKind_Mask]> {
   let cppNamespace = "::P4::P4MLIR::P4HIR";
 }
 
 def P4HIR_SetAttr : P4HIR_Attr<"Set", "set", [TypedAttrInterface]> {
   let summary = "An attribute containing a set value";
   let description = [{
-    A set attribute is a literal attribute that represents a set of values
-    of the specified type. Only certain well-described types of sets are
-    supported as well as their products.
+    A set attribute is a literal attribute that represents a set of values of
+    the specified type. Only certain well-described types of sets are supported.
   }];
   let parameters = (ins AttributeSelfTypeParameter<"">:$type,
                         "SetKind":$kind,

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.td
@@ -299,11 +299,40 @@ def P4HIR_SetAttr : P4HIR_Attr<"Set", "set", [TypedAttrInterface]> {
       return $_get(type.getContext(), type, kind, members);
     }]>
   ];
+  let extraClassDeclaration = [{
+    llvm::APInt getConstantValue() {
+      assert(getKind() == SetKind::Constant && "Expected Constant kind set.");
+      assert(getMembers().size() == 1 && "Expected single member set.");
+      return P4HIR::getConstantInt(getMembers()[0]).value();
+    }
+
+    std::pair<llvm::APInt, llvm::APInt> getRangeValues() {
+      assert(getKind() == SetKind::Range && "Expected Range kind set.");
+      return {
+        P4HIR::getConstantInt(getMembers()[0]).value(),
+        P4HIR::getConstantInt(getMembers()[1]).value()
+      };
+    }
+
+    std::pair<llvm::APInt, llvm::APInt> getMaskValues() {
+      assert(getKind() == SetKind::Mask && "Expected Mask kind set.");
+      return {
+        P4HIR::getConstantInt(getMembers()[0]).value(),
+        P4HIR::getConstantInt(getMembers()[1]).value()
+      };
+    }
+
+    bool isEmptyRange() {
+      assert(getKind() == SetKind::Range && "Expected Range kind set.");
+      auto min = P4HIR::getConstantInt(getMembers()[0]).value();
+      auto max = P4HIR::getConstantInt(getMembers()[1]).value();
+      return max < min;
+    }
+  }];
   let genVerifyDecl = 1;
   let assemblyFormat = [{
     `<` $kind `:` $members `>`
   }];
-
 }
 
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.h
@@ -23,6 +23,7 @@
 
 namespace P4::P4MLIR::P4HIR {
 void buildTerminatedBody(mlir::OpBuilder &builder, mlir::Location loc);
+bool isUniversalSetValue(mlir::Value value);
 }  // namespace  P4::P4MLIR::P4HIR
 
 #define GET_OP_CLASSES

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -382,6 +382,7 @@ def ConcatOp : P4HIR_Op<"concat", [Pure]> {
   ];
 
   let hasVerifier = 1;
+  let hasFolder = 1;
 
   let assemblyFormat = [{
     `(` $lhs `:` type($lhs) `,` $rhs `:` type($rhs) `)` `:` type($result) attr-dict

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1153,6 +1153,7 @@ def TupleExtractOp : P4HIR_Op<"tuple_extract",
   let arguments = (ins Builtin_Tuple:$input, I32Attr:$fieldIndex);
   // FIXME: Better constraint type
   let results = (outs AnyP4Type:$result);
+  let hasFolder = 1;
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$input, "unsigned":$fieldIndex)>,

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
@@ -172,6 +172,7 @@ def ParserTransitionSelectOp : P4HIR_Op<"transition_select",
      return { StateIterator(selectCases.begin()), StateIterator(selectCases.end()) };
    }
  }];
+ let hasCanonicalizeMethod = 1;
 }
 
 def ParserSelectCaseOp : P4HIR_Op<"select_case",

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
@@ -196,6 +196,7 @@ def ParserSelectCaseOp : P4HIR_Op<"select_case",
   ];
 
   let extraClassDeclaration = [{
+    mlir::Operation *getTerminator() { return getRegion().front().getTerminator(); }
     bool isDefault();
     mlir::ValueRange getSelectKeys();
   }];

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
@@ -142,10 +142,10 @@ def ParserTransitionSelectOp : P4HIR_Op<"transition_select",
    [Terminator, NoTerminator,
     ParentOneOf<["ParserStateOp"]>]> {
   // FIXME: constraint argument better. Should be tuple or "normal" type.
-  let arguments = (ins AnyP4Type:$select);
+  let arguments = (ins Variadic<AnyP4Type>:$args);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $select `:` type($select) $body attr-dict
+    $args `:` type($args) $body attr-dict
   }];
   // FIXME: Implement verifier for cases
 
@@ -197,7 +197,7 @@ def ParserSelectCaseOp : P4HIR_Op<"select_case",
 
   let extraClassDeclaration = [{
     bool isDefault();
-    mlir::Value getSelectKey();
+    mlir::ValueRange getSelectKeys();
   }];
 }
 
@@ -207,28 +207,6 @@ def SetOp : P4HIR_Op<"set",
   let summary = "Create a set from constituent parts.";
   // FIXME: Better constraint type
   let arguments = (ins Variadic<AnyP4Type>:$input);
-  let results = (outs SetType:$result);
-  let hasCustomAssemblyFormat = 1;
-  // FIXME: use declarative format
-  // let assemblyFormat = [{
-  //   `(` $input `)` attr-dict `:` type($result)
-  // }];
-
-  // TODO: Automatically infer result type
-  let builders = [
-    OpBuilder<(ins "mlir::ValueRange":$input)>
-  ];
-
-  let hasVerifier = 1;
-  let hasFolder = 1;
-}
-
-def SetProductOp : P4HIR_Op<"set_product",
-   [Pure,
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
-  let summary = "Create a carthesian set product";
-  // FIXME: Better constraint type
-  let arguments = (ins Variadic<SetType>:$input);
   let results = (outs SetType:$result);
   let hasCustomAssemblyFormat = 1;
   // FIXME: use declarative format

--- a/include/p4mlir/Transforms/Passes.h
+++ b/include/p4mlir/Transforms/Passes.h
@@ -24,12 +24,14 @@ namespace P4::P4MLIR {
 //===----------------------------------------------------------------------===//
 
 #define GEN_PASS_DECL_SIMPLIFYPARSERS
+#define GEN_PASS_DECL_SIMPLIFYSELECT
 #define GEN_PASS_DECL_SERENUMELIMINATION
 #define GEN_PASS_DECL_REMOVEALIASES
 #include "p4mlir/Transforms/Passes.h.inc"
 
 std::unique_ptr<mlir::Pass> createPrintParsersGraphPass();
 std::unique_ptr<mlir::Pass> createSimplifyParsersPass();
+std::unique_ptr<mlir::Pass> createSimplifySelectPass();
 std::unique_ptr<mlir::Pass> createFlattenCFGPass();
 std::unique_ptr<mlir::Pass> createSerEnumEliminationPass();
 std::unique_ptr<mlir::Pass> createRemoveAliasesPass();

--- a/include/p4mlir/Transforms/Passes.td
+++ b/include/p4mlir/Transforms/Passes.td
@@ -96,6 +96,9 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
       (8w2 &&& 8w0xfe): next;
       (8w4 &&& 8w0xfc): next;
       (8w8 &&& 8w0xff): next;
+
+    - concat-args
+    Convert multiple select arguments to a single one by concatenation.
   }];
 
   let constructor = "P4MLIR::createSimplifySelectPass()";
@@ -110,6 +113,8 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
            "Replace constant ranges in keysest with an appropriate list of masks">,
     Option<"replaceRangesCaseCountLimit", "replace-ranges-case-limit", "size_t", /*default=*/"100",
            "Do not replace ranges if the resuling case count exceeds this limit">,
+    Option<"concatArgs", "concat-args", "bool", /*default=*/"true",
+           "Convert multiple select arguments to a single one by concatenation">,
   ];
 }
 

--- a/include/p4mlir/Transforms/Passes.td
+++ b/include/p4mlir/Transforms/Passes.td
@@ -79,6 +79,9 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
         (1, false, 8w1, true): accept;
         ...
       }
+
+    - replace-bool
+    Replace bool arguments with bit<1> by inserting appropriate casts.
   }];
 
   let constructor = "P4MLIR::createSimplifySelectPass()";
@@ -87,6 +90,8 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
   let options = [
     Option<"flattenTuples", "flatten-tuples", "bool", /*default=*/"true",
            "Flatten tuples found in select arguments and keyset expressions">,
+    Option<"replaceBools", "replace-bools", "bool", /*default=*/"true",
+           "Replace bool arguments with bit<1> by inserting appropriate casts">,
   ];
 }
 

--- a/include/p4mlir/Transforms/Passes.td
+++ b/include/p4mlir/Transforms/Passes.td
@@ -82,6 +82,20 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
 
     - replace-bool
     Replace bool arguments with bit<1> by inserting appropriate casts.
+
+    - replace-ranges
+    Replace constant ranges in keysest with an appropriate list of masks.
+    Example:
+
+    Before:
+      ...
+      (8w2..8w8): next;
+
+    After:
+      ...
+      (8w2 &&& 8w0xfe): next;
+      (8w4 &&& 8w0xfc): next;
+      (8w8 &&& 8w0xff): next;
   }];
 
   let constructor = "P4MLIR::createSimplifySelectPass()";
@@ -92,6 +106,10 @@ def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
            "Flatten tuples found in select arguments and keyset expressions">,
     Option<"replaceBools", "replace-bools", "bool", /*default=*/"true",
            "Replace bool arguments with bit<1> by inserting appropriate casts">,
+    Option<"replaceRanges", "replace-ranges", "bool", /*default=*/"true",
+           "Replace constant ranges in keysest with an appropriate list of masks">,
+    Option<"replaceRangesCaseCountLimit", "replace-ranges-case-limit", "size_t", /*default=*/"100",
+           "Do not replace ranges if the resuling case count exceeds this limit">,
   ];
 }
 

--- a/include/p4mlir/Transforms/Passes.td
+++ b/include/p4mlir/Transforms/Passes.td
@@ -53,6 +53,44 @@ def SimplifyParsers : Pass<"p4hir-simplify-parsers"> {
 }
 
 //===----------------------------------------------------------------------===//
+// SimplifySelect
+//===----------------------------------------------------------------------===//
+
+def SimplifySelect : Pass<"p4hir-simplify-select", "P4HIR::ParserOp"> {
+  let summary = "Simplifies select statements";
+  let description = [{
+    This pass implements a number of simplifications for transition select statements.
+    It consists of the following optimizations:
+
+    - flatten-tuples
+    Flatten tuples in select arguments and keysets as much as possible.
+    Example:
+
+    Before:
+      bit<8> x; bool y;
+      transition select(x, {y}, {x * 3, {y}}) {
+        (1, {false}, {8w1, {true}}): accept;
+        ...
+      }
+
+    After:
+      bit<8> x; bool y;
+      transition select(x, y, x * 3, y) {
+        (1, false, 8w1, true): accept;
+        ...
+      }
+  }];
+
+  let constructor = "P4MLIR::createSimplifySelectPass()";
+  let dependentDialects = ["P4MLIR::P4HIR::P4HIRDialect"];
+
+  let options = [
+    Option<"flattenTuples", "flatten-tuples", "bool", /*default=*/"true",
+           "Flatten tuples found in select arguments and keyset expressions">,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // FlattenCFG
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
@@ -291,17 +291,7 @@ LogicalResult SetAttr::verify(function_ref<InFlightDiagnostic()> emitError, Type
                 emitError() << "p4hir.set elements must be of the same type: " << eltType;
                 return failure();
             }
-            break;
 
-            break;
-        case SetKind::Prod:
-            // Must be either SetAttr or UniversalSetAttr
-            if (llvm::any_of(value.getAsRange<mlir::TypedAttr>(), [&](auto attr) {
-                    return !mlir::isa<P4HIR::SetType>(attr.getType());
-                })) {
-                emitError() << "p4hir.set product elements must be of set type all";
-                return failure();
-            }
             break;
     }
 

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -299,6 +299,16 @@ LogicalResult P4HIR::ConcatOp::verify() {
     return success();
 }
 
+OpFoldResult P4HIR::ConcatOp::fold(FoldAdaptor adaptor) {
+    if (adaptor.getLhs() && adaptor.getRhs()) {
+        auto lhs = P4HIR::getConstantInt(adaptor.getLhs()).value();
+        auto rhs = P4HIR::getConstantInt(adaptor.getRhs()).value();
+        return P4HIR::IntAttr::get(getType(), lhs.concat(rhs));
+    }
+
+    return {};
+}
+
 //===----------------------------------------------------------------------===//
 // ShlOp & ShrOp
 //===----------------------------------------------------------------------===//

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(P4MLIRTransforms
   RemoveAliases.cpp
   SerEnumElimination.cpp
   SimplifyParsers.cpp
+  SimplifySelect.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/p4mlir/Transforms

--- a/lib/Transforms/SimplifySelect.cpp
+++ b/lib/Transforms/SimplifySelect.cpp
@@ -1,0 +1,160 @@
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "p4mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "p4hir-simplify-select"
+
+namespace P4::P4MLIR {
+#define GEN_PASS_DEF_SIMPLIFYSELECT
+#include "p4mlir/Transforms/Passes.cpp.inc"
+
+namespace {
+
+struct SimplifySelect : public impl::SimplifySelectBase<SimplifySelect> {
+    void runOnOperation() override;
+};
+
+// Flatten all tuples in transition_select arguments and case keysets.
+class FlattenTuples : public mlir::OpRewritePattern<P4HIR::ParserTransitionSelectOp> {
+ public:
+    using OpRewritePattern<P4HIR::ParserTransitionSelectOp>::OpRewritePattern;
+
+    mlir::LogicalResult matchAndRewrite(P4HIR::ParserTransitionSelectOp selectOp,
+                                        mlir::PatternRewriter &rewriter) const override {
+        auto selectArgs = selectOp.getArgs();
+        bool hasTupleArgs = llvm::any_of(
+            selectArgs, [](mlir::Value v) { return mlir::isa<mlir::TupleType>(v.getType()); });
+
+        if (!hasTupleArgs)
+            return rewriter.notifyMatchFailure(selectOp.getLoc(),
+                                               "Select doesn't have tuple arguments.");
+
+        // First flatten yields in case stetamenets.
+        for (auto selectCase : selectOp.selects()) {
+            auto yield = mlir::cast<P4HIR::YieldOp>(selectCase.getTerminator());
+            rewriter.setInsertionPoint(yield);
+
+            llvm::SmallVector<mlir::Value, 4> newArgs;
+            auto callback = [&](mlir::Value value) {
+                // Re-wrap case keys with p4hir.set if needed.
+                if (!mlir::isa<P4HIR::SetType>(value.getType())) {
+                    value = rewriter.create<P4HIR::SetOp>(value.getLoc(), mlir::ValueRange(value));
+                }
+
+                newArgs.push_back(value);
+                return true;
+            };
+
+            [[maybe_unused]] bool compatible =
+                flattenValues(rewriter, selectArgs.getTypes(), yield.getArgs(), true, callback);
+            assert(compatible && "The structure of yield and select args must match.");
+
+            rewriter.modifyOpInPlace(selectOp, [&]() { yield.getArgsMutable().assign(newArgs); });
+        }
+
+        // Finally flatten the arguments of the select statement.
+        llvm::SmallVector<mlir::Value, 4> newArgs;
+        rewriter.setInsertionPoint(selectOp);
+        flattenValues(rewriter, selectArgs.getTypes(), selectArgs, false, [&](mlir::Value value) {
+            newArgs.push_back(value);
+            return true;
+        });
+
+        rewriter.modifyOpInPlace(selectOp, [&]() { selectOp.getArgsMutable().assign(newArgs); });
+
+        return mlir::success();
+    }
+
+ private:
+    // Helper to flatten `keys` based on the argument types of a select statement. `shape` and
+    // `keys` are lists of types and values that may be primitives (int, bool, ...), tuples
+    // of such primitives or sets. Performs a DFS traversal based on the structure of `shape`
+    // and report `keys`'s leaf nodes through `callback`. If `allowUnwrapSet` is true then
+    // allow to look through a p4hir.set operation once. Return true iff the structure of `shape`
+    // and `keys` is compatible.
+    static bool flattenValues(mlir::PatternRewriter &rewriter, mlir::TypeRange shape,
+                              mlir::ValueRange keys, bool allowUnwrapSet,
+                              llvm::function_ref<bool(mlir::Value)> callback) {
+        bool isKeysUniversalSet = false;
+        llvm::SmallVector<mlir::Value, 4> keysStorage;
+
+        if (keys.size() == 1) {
+            if (P4HIR::isUniversalSetValue(keys.front())) {
+                isKeysUniversalSet = true;
+            } else if (auto setOp = keys.front().getDefiningOp<P4HIR::SetOp>();
+                       setOp && allowUnwrapSet) {
+                keys = setOp.getInput();
+                allowUnwrapSet = false;
+            }
+        }
+
+        // If `shape` is a tuple type then unpack it together with `keys`.
+        if (shape.size() == 1) {
+            if (keys.size() != 1) return false;
+
+            if (auto tupleType1 = mlir::dyn_cast<mlir::TupleType>(shape.front())) {
+                shape = tupleType1.getTypes();
+
+                if (!isKeysUniversalSet) {
+                    mlir::Value val = keys.front();
+                    auto tupleType2 = mlir::dyn_cast<mlir::TupleType>(val.getType());
+                    if (!tupleType2 || tupleType2.getTypes().size() != shape.size()) return false;
+
+                    for (size_t i = 0; i < shape.size(); i++)
+                        keysStorage.push_back(
+                            rewriter.create<P4HIR::TupleExtractOp>(val.getLoc(), val, i));
+
+                    keys = keysStorage;
+                }
+            }
+        }
+
+        if (shape.size() != keys.size() && !isKeysUniversalSet) return false;
+
+        bool isShapePrimitive = (shape.size() == 1) && !mlir::isa<mlir::TupleType>(shape.front());
+
+        if (isShapePrimitive) {
+            return callback(keys.front());
+        }
+
+        if (isKeysUniversalSet) {
+            for (auto childShape : shape)
+                if (!flattenValues(rewriter, childShape, keys, allowUnwrapSet, callback))
+                    return false;
+        } else {
+            for (auto [childShape, value] : llvm::zip_equal(shape, keys))
+                if (!flattenValues(rewriter, childShape, value, allowUnwrapSet, callback))
+                    return false;
+        }
+
+        return true;
+    }
+};
+
+}  // end namespace
+
+void SimplifySelect::runOnOperation() {
+    mlir::RewritePatternSet patterns(&getContext());
+
+    if (flattenTuples) patterns.add<FlattenTuples>(patterns.getContext());
+
+    // Collect operations and apply patterns.
+    llvm::SmallVector<mlir::Operation *, 16> ops;
+    getOperation()->walk([&](P4HIR::ParserTransitionSelectOp op) { ops.push_back(op); });
+
+    mlir::GreedyRewriteConfig config;
+    config.strictMode = mlir::GreedyRewriteStrictness::ExistingOps;
+    auto result = applyOpPatternsGreedily(ops, std::move(patterns), config);
+
+    if (result.failed()) signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> createSimplifySelectPass() {
+    return std::make_unique<SimplifySelect>();
+}
+}  // namespace P4::P4MLIR

--- a/test/Dialect/P4HIR/parser.mlir
+++ b/test/Dialect/P4HIR/parser.mlir
@@ -19,15 +19,13 @@ module {
   p4hir.parser @p2(%arg0: !b10i, %arg1: !p4hir.ref<!p4hir.bool>)() {
     p4hir.state @start {
       %true = p4hir.const #true
-      %tuple = p4hir.tuple (%arg0, %true) : tuple<!b10i, !p4hir.bool>
-      p4hir.transition_select %tuple : tuple<!b10i, !p4hir.bool> {
+      p4hir.transition_select %arg0, %true : !b10i, !p4hir.bool {
         p4hir.select_case {
           %c1_b10i = p4hir.const #int1_b10i
           %set = p4hir.set (%c1_b10i) : !p4hir.set<!b10i>
           %false = p4hir.const #false
           %set_0 = p4hir.set (%false) : !p4hir.set<!p4hir.bool>
-          %setproduct = p4hir.set_product (%set, %set_0) : !p4hir.set<tuple<!b10i, !p4hir.bool>>
-          p4hir.yield %setproduct : !p4hir.set<tuple<!b10i, !p4hir.bool>>
+          p4hir.yield %set, %set_0 : !p4hir.set<!b10i>, !p4hir.set<!p4hir.bool>
         } to @p2::@drop
         p4hir.select_case {
           %c10_b10i = p4hir.const #int10_b10i
@@ -35,22 +33,19 @@ module {
           %range = p4hir.range(%c10_b10i, %c20_b10i) : !p4hir.set<!b10i>
           %true_0 = p4hir.const #true
           %set = p4hir.set (%true_0) : !p4hir.set<!p4hir.bool>
-          %setproduct = p4hir.set_product (%range, %set) : !p4hir.set<tuple<!b10i, !p4hir.bool>>
-          p4hir.yield %setproduct : !p4hir.set<tuple<!b10i, !p4hir.bool>>
+          p4hir.yield %range, %set : !p4hir.set<!b10i>, !p4hir.set<!p4hir.bool>
         } to @p2::@next
         p4hir.select_case {
           %c0_b10i = p4hir.const #int0_b10i
           %c0_b10i_0 = p4hir.const #int0_b10i
           %mask = p4hir.mask(%c0_b10i, %c0_b10i_0) : !p4hir.set<!b10i>
           %everything = p4hir.const #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
-          %setproduct = p4hir.set_product (%mask, %everything) : !p4hir.set<tuple<!b10i, !p4hir.dontcare>>
-          p4hir.yield %setproduct : !p4hir.set<tuple<!b10i, !p4hir.dontcare>>
+          p4hir.yield %mask, %everything : !p4hir.set<!b10i>, !p4hir.set<!p4hir.dontcare>
         } to @p2::@next
         p4hir.select_case {
           %everything = p4hir.const #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
           %everything_0 = p4hir.const #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
-          %setproduct = p4hir.set_product (%everything, %everything_0) : !p4hir.set<tuple<!p4hir.dontcare, !p4hir.dontcare>>
-          p4hir.yield %setproduct : !p4hir.set<tuple<!p4hir.dontcare, !p4hir.dontcare>>
+          p4hir.yield %everything, %everything_0 : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>
         } to @p2::@reject
         p4hir.select_case {
           %everything = p4hir.const #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>

--- a/test/Transforms/Folds/cast.mlir
+++ b/test/Transforms/Folds/cast.mlir
@@ -1,6 +1,7 @@
 // RUN: p4mlir-opt --canonicalize %s | FileCheck %s
 
 !i8i = !p4hir.int<8>
+!i16i = !p4hir.int<16>
 !b8i = !p4hir.bit<8>
 !infint = !p4hir.infint
 #false = #p4hir.bool<false> : !p4hir.bool
@@ -20,12 +21,14 @@
 
 // CHECK-LABEL: module
 module {
+  // CHECK: %[[cm128_i16i:.*]] = p4hir.const #int-128_i16i
   // CHECK: %[[cm42_i8i:.*]] = p4hir.const #int-42_i8i
   // CHECK: %[[c1_i8i:.*]] = p4hir.const #int1_i8i
   // CHECK: %[[c0_i8i:.*]] = p4hir.const #int0_i8i
   // CHECK: %[[cm128_i8i:.*]] = p4hir.const #int-128_i8i
   
-  p4hir.func @blackhole(!i8i)
+  p4hir.func @blackhole_i8i(!i8i)
+  p4hir.func @blackhole_i16i(!i16i)
 
   %c-128_i8i = p4hir.const #int-128_i8i
   %false = p4hir.const #false
@@ -34,27 +37,33 @@ module {
   %c-42 = p4hir.const #int-42_infint
 
   %cast1 = p4hir.cast(%c-128_i8i : !i8i) : !i8i
-  p4hir.call @blackhole(%cast1) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast1) : (!i8i) -> ()
 
-  // CHECK: p4hir.call @blackhole (%[[cm128_i8i]]) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm128_i8i]]) : (!i8i) -> ()
   
   %cast2 = p4hir.cast(%false : !p4hir.bool) : !i8i
-  p4hir.call @blackhole(%cast2) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%c0_i8i) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast2) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%c0_i8i) : (!i8i) -> ()
   
   %cast3 = p4hir.cast(%true : !p4hir.bool) : !i8i
-  p4hir.call @blackhole(%cast3) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%[[c1_i8i]]) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast3) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[c1_i8i]]) : (!i8i) -> ()
 
   %cast4 = p4hir.cast(%c-42 : !p4hir.infint) : !i8i
-  p4hir.call @blackhole(%cast4) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%[[cm42_i8i]]) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast4) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm42_i8i]]) : (!i8i) -> ()
 
   %castA = p4hir.cast(%cast1 : !i8i) : !b8i
   %castB = p4hir.cast(%castA : !b8i) : !i8i
-  p4hir.call @blackhole(%castB) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%castB) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm128_i8i]]) : (!i8i) -> ()
 
   %Suits_Clubs = p4hir.const #Suits_Clubs
   %cast5 = p4hir.cast(%Suits_Clubs : !SuitsSerializable) : !i8i
-  p4hir.call @blackhole(%cast5) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast5) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[c1_i8i]]) : (!i8i) -> ()
+
+  %cast6 = p4hir.cast(%c-128_i8i : !i8i) : !i16i
+  p4hir.call @blackhole_i16i(%cast6) : (!i16i) -> ()
+  // CHECK: p4hir.call @blackhole_i16i (%[[cm128_i16i]]) : (!i16i) -> ()
 }

--- a/test/Transforms/Folds/select.mlir
+++ b/test/Transforms/Folds/select.mlir
@@ -1,0 +1,80 @@
+// RUN: p4mlir-opt --canonicalize %s | FileCheck %s
+
+!b8i = !p4hir.bit<8>
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+#false = #p4hir.bool<false> : !p4hir.bool
+#true = #p4hir.bool<true> : !p4hir.bool
+#int1_b8i = #p4hir.int<1> : !b8i
+#int2_b8i = #p4hir.int<2> : !b8i
+#int8_b8i = #p4hir.int<8> : !b8i
+#set_const_of_false = #p4hir.set<const : [#false]> : !p4hir.set<!p4hir.bool>
+#set_const_of_true = #p4hir.set<const : [#true]> : !p4hir.set<!p4hir.bool>
+#set_const_of_int1_b8i = #p4hir.set<const : [#int1_b8i]> : !p4hir.set<!b8i>
+#set_const_of_int2_b8i = #p4hir.set<const : [#int2_b8i]> : !p4hir.set<!b8i>
+#set_const_of_int8_b8i = #p4hir.set<const : [#int8_b8i]> : !p4hir.set<!b8i>
+
+// CHECK-LABEL: module
+module {
+  p4hir.parser @p1(%arg0: !b8i, %arg1: !p4hir.bool)() {
+    %set = p4hir.const #set_const_of_int8_b8i
+    %set_0 = p4hir.const #set_const_of_true
+    %set_1 = p4hir.const #set_const_of_int2_b8i
+    %set_2 = p4hir.const #set_const_of_false
+    %set_3 = p4hir.const #set_const_of_int1_b8i
+    %everything = p4hir.const #everything
+
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      // CHECK-COUNT-2: p4hir.select_case
+      // CHECK-NOT: p4hir.yield %everything, %everything : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>
+      // CHECK: p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+      // Remove dead cases; canonicalize default cases.
+      p4hir.transition_select %arg0, %arg1 : !b8i, !p4hir.bool {
+        p4hir.select_case {
+          p4hir.yield %set_3, %set_2 : !p4hir.set<!b8i>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %everything, %everything : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>
+        } to @p1::@next
+        p4hir.select_case {
+          p4hir.yield %set_1, %set_0 : !p4hir.set<!b8i>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+      }
+    }
+
+    // CHECK-LABEL: p4hir.state @next
+    p4hir.state @next {
+      // CHECK-NOT: p4hir.select_case
+      // CHECK: p4hir.transition to @p1::@final
+      // Replace select with one default case with direct transition.
+      p4hir.transition_select %arg0, %arg1 : !b8i, !p4hir.bool {
+        p4hir.select_case {
+          p4hir.yield %everything, %everything : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>
+        } to @p1::@final
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %set, %set_2 : !p4hir.set<!b8i>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@reject
+      }
+    }
+
+    p4hir.state @final {
+      p4hir.transition to @p1::@accept
+    }
+
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+
+    p4hir.transition to @p1::@start
+  }
+}

--- a/test/Transforms/Folds/set.mlir
+++ b/test/Transforms/Folds/set.mlir
@@ -6,7 +6,6 @@
 
 // CHECK-DAG: #[[set_const_of_int1_b10i:.*]] = #p4hir.set<const : [#int1_b10i]> : !p4hir.set<!b10i>
 // CHECK-DAG: #[[set_const_of_int1_b10i_int10_b10i:.*]] = #p4hir.set<const : [#int1_b10i, #int10_b10i]> : !p4hir.set<!b10i>
-// CHECK: #[[set_prod_of_set_const_of_int1_b10i_set_const_of_int1_b10i_int10_b10i:.*]] = #p4hir.set<prod : [#[[set_const_of_int1_b10i]], #[[set_const_of_int1_b10i_int10_b10i]]]> : !p4hir.set<tuple<!b10i, !b10i>>
 
 // CHECK-LABEL: module
 module {
@@ -16,7 +15,6 @@ module {
   %c1_b10i = p4hir.const #int1_b10i
   %c10_b10i = p4hir.const #int10_b10i
 
-  // CHECK-DAG: p4hir.const #set_prod_of_set_const_of_int1_b10i_set_const_of_int1_b10i_int10_b10i
   // CHECK-DAG: p4hir.const #set_const_of_int1_b10i_int10_b10i
   // CHECK-DAG: p4hir.const #set_const_of_int1_b10i
 
@@ -34,7 +32,4 @@ module {
   // CHECK: p4hir.set (%{{.*}}, %{{.*}}, %[[val]]) : !p4hir.set<!b10i>
   %set3 = p4hir.set (%c1_b10i, %c10_b10i, %val) : !p4hir.set<!b10i>
   p4hir.call @blackhole(%set3) : (!p4hir.set<!b10i>) -> ()
-
-  %set4 = p4hir.set_product (%set, %set2) : !p4hir.set<tuple<!b10i, !b10i>>
-  p4hir.call @blackhole_t(%set4) : (!p4hir.set<tuple<!b10i, !b10i>>) -> ()
 }

--- a/test/Transforms/Passes/simplify-select-concat-args.mlir
+++ b/test/Transforms/Passes/simplify-select-concat-args.mlir
@@ -1,0 +1,62 @@
+// RUN: p4mlir-opt --p4hir-simplify-select="flatten-tuples=false replace-bools=false replace-ranges=true concat-args=true" --canonicalize %s | FileCheck %s
+
+!b2i = !p4hir.bit<2>
+!b4i = !p4hir.bit<4>
+!i8i = !p4hir.int<8>
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+#int1_b2i = #p4hir.int<1> : !b2i
+#int2_b4i = #p4hir.int<2> : !b4i
+#int2_i8i = #p4hir.int<2> : !i8i
+#int3_b4i = #p4hir.int<3> : !b4i
+#int4_i8i = #p4hir.int<4> : !i8i
+#set_const_of_int1_b2i = #p4hir.set<const : [#int1_b2i]> : !p4hir.set<!b2i>
+#set_const_of_int2_i8i = #p4hir.set<const : [#int2_i8i]> : !p4hir.set<!i8i>
+#set_const_of_int3_b4i = #p4hir.set<const : [#int3_b4i]> : !p4hir.set<!b4i>
+#set_const_of_int4_i8i = #p4hir.set<const : [#int4_i8i]> : !p4hir.set<!i8i>
+#set_mask_of_int1_b2i_int1_b2i = #p4hir.set<mask : [#int1_b2i, #int1_b2i]> : !p4hir.set<!b2i>
+#set_mask_of_int2_b4i_int2_b4i = #p4hir.set<mask : [#int2_b4i, #int2_b4i]> : !p4hir.set<!b4i>
+
+// CHECK-NOT: #p4hir.universal_set
+
+// CHECK-LABEL: module
+module {
+  p4hir.parser @p1(%arg0: !b2i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "a"}, %arg1: !i8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "b"}, %arg2: !b4i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "c"})() {
+    %c3_b4i = p4hir.const #int3_b4i
+    %set = p4hir.const #set_mask_of_int2_b4i_int2_b4i
+    %set_0 = p4hir.const #set_const_of_int4_i8i
+    %set_1 = p4hir.const #set_mask_of_int1_b2i_int1_b2i
+    %set_2 = p4hir.const #set_const_of_int3_b4i
+    %set_3 = p4hir.const #set_const_of_int2_i8i
+    %set_4 = p4hir.const #set_const_of_int1_b2i
+    %everything = p4hir.const #everything
+
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      // CHECK: p4hir.concat
+      // CHECK: p4hir.transition_select %{{.*}} : !b14i {
+      // CHECK-COUNT-4: p4hir.yield %{{.*}} : !p4hir.set<!b14i>
+      p4hir.transition_select %arg0, %arg1, %arg2 : !b2i, !i8i, !b4i {
+        p4hir.select_case {
+          p4hir.yield %set_4, %set_3, %set_2 : !p4hir.set<!b2i>, !p4hir.set<!i8i>, !p4hir.set<!b4i>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %set_1, %set_0, %set : !p4hir.set<!b2i>, !p4hir.set<!i8i>, !p4hir.set<!b4i>
+        } to @p1::@reject
+        p4hir.select_case {
+          %mask = p4hir.mask(%arg2, %c3_b4i) : !p4hir.set<!b4i>
+          p4hir.yield %set_1, %everything, %mask : !p4hir.set<!b2i>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!b4i>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@accept
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p1::@start
+  }
+}

--- a/test/Transforms/Passes/simplify-select-flatten-tuples.mlir
+++ b/test/Transforms/Passes/simplify-select-flatten-tuples.mlir
@@ -1,0 +1,144 @@
+// RUN: p4mlir-opt --p4hir-simplify-select="flatten-tuples=true replace-bools=false replace-ranges=false concat-args=false" --canonicalize %s | FileCheck %s
+
+!b8i = !p4hir.bit<8>
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+#false = #p4hir.bool<false> : !p4hir.bool
+#true = #p4hir.bool<true> : !p4hir.bool
+#int1_b8i = #p4hir.int<1> : !b8i
+#int2_b8i = #p4hir.int<2> : !b8i
+#int34_b8i = #p4hir.int<34> : !b8i
+#int3_b8i = #p4hir.int<3> : !b8i
+#set_const_of_true = #p4hir.set<const : [#true]> : !p4hir.set<!p4hir.bool>
+#set_const_of_int1_b8i = #p4hir.set<const : [#int1_b8i]> : !p4hir.set<!b8i>
+#set_const_of_int2_b8i = #p4hir.set<const : [#int2_b8i]> : !p4hir.set<!b8i>
+#set_const_of_int3_b8i = #p4hir.set<const : [#int3_b8i]> : !p4hir.set<!b8i>
+
+// Flatten all tuples in this select statement.
+//   transition select(x, {{y}}, {y}, y, {x + 1, !y}) {
+//     (1, {{false}}, {true}, w, {8w1, false}): reject;
+//     (2, default, {true}, true, default): reject;
+//     (3, {{true}}, default, true, {8w34, true}): reject;
+//     default: accept;
+//   }
+// CHECK-LABEL: module
+module {
+  // CHECK-LABEL: p4hir.parser @p1
+  p4hir.parser @p1(%arg0: !b8i, %arg1: !p4hir.bool)() {
+    %set = p4hir.const #set_const_of_int3_b8i
+    %set_0 = p4hir.const #set_const_of_true
+    %set_1 = p4hir.const #set_const_of_int2_b8i
+    %set_2 = p4hir.const #set_const_of_int1_b8i
+    %c34_b8i = p4hir.const #int34_b8i
+    %everything = p4hir.const #everything
+    %true = p4hir.const #true
+    %c1_b8i = p4hir.const #int1_b8i
+    %false = p4hir.const #false
+    %w = p4hir.variable ["w", init] : <!p4hir.bool>
+    p4hir.assign %false, %w : <!p4hir.bool>
+
+    // CHECK-LABEL: p4hir.state @start
+    // CHECK-NOT: tuple
+    p4hir.state @start {
+      %tuple = p4hir.tuple (%arg1) : tuple<!p4hir.bool>
+      %tuple_3 = p4hir.tuple (%tuple) : tuple<tuple<!p4hir.bool>>
+      %tuple_4 = p4hir.tuple (%arg1) : tuple<!p4hir.bool>
+      %add = p4hir.binop(add, %arg0, %c1_b8i) : !b8i
+      %not = p4hir.unary(not, %arg1) : !p4hir.bool
+      %tuple_5 = p4hir.tuple (%add, %not) : tuple<!b8i, !p4hir.bool>
+      p4hir.transition_select %arg0, %tuple_3, %tuple_4, %arg1, %tuple_5 : !b8i, tuple<tuple<!p4hir.bool>>, tuple<!p4hir.bool>, !p4hir.bool, tuple<!b8i, !p4hir.bool> {
+        p4hir.select_case {
+          %tuple_6 = p4hir.tuple (%false) : tuple<!p4hir.bool>
+          %tuple_7 = p4hir.tuple (%tuple_6) : tuple<tuple<!p4hir.bool>>
+          %set_8 = p4hir.set (%tuple_7) : !p4hir.set<tuple<tuple<!p4hir.bool>>>
+          %tuple_9 = p4hir.tuple (%true) : tuple<!p4hir.bool>
+          %set_10 = p4hir.set (%tuple_9) : !p4hir.set<tuple<!p4hir.bool>>
+          %val = p4hir.read %w : <!p4hir.bool>
+          %set_11 = p4hir.set (%val) : !p4hir.set<!p4hir.bool>
+          %tuple_12 = p4hir.tuple (%c1_b8i, %false) : tuple<!b8i, !p4hir.bool>
+          %set_13 = p4hir.set (%tuple_12) : !p4hir.set<tuple<!b8i, !p4hir.bool>>
+          p4hir.yield %set_2, %set_8, %set_10, %set_11, %set_13 : !p4hir.set<!b8i>, !p4hir.set<tuple<tuple<!p4hir.bool>>>, !p4hir.set<tuple<!p4hir.bool>>, !p4hir.set<!p4hir.bool>, !p4hir.set<tuple<!b8i, !p4hir.bool>>
+        } to @p1::@accept
+        p4hir.select_case {
+          %tuple_6 = p4hir.tuple (%true) : tuple<!p4hir.bool>
+          %set_7 = p4hir.set (%tuple_6) : !p4hir.set<tuple<!p4hir.bool>>
+          p4hir.yield %set_1, %everything, %set_7, %set_0, %everything : !p4hir.set<!b8i>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<tuple<!p4hir.bool>>, !p4hir.set<!p4hir.bool>, !p4hir.set<!p4hir.dontcare>
+        } to @p1::@reject
+        p4hir.select_case {
+          %tuple_6 = p4hir.tuple (%true) : tuple<!p4hir.bool>
+          %tuple_7 = p4hir.tuple (%tuple_6) : tuple<tuple<!p4hir.bool>>
+          %set_8 = p4hir.set (%tuple_7) : !p4hir.set<tuple<tuple<!p4hir.bool>>>
+          %tuple_9 = p4hir.tuple (%c34_b8i, %true) : tuple<!b8i, !p4hir.bool>
+          %set_10 = p4hir.set (%tuple_9) : !p4hir.set<tuple<!b8i, !p4hir.bool>>
+          p4hir.yield %set, %set_8, %everything, %set_0, %set_10 : !p4hir.set<!b8i>, !p4hir.set<tuple<tuple<!p4hir.bool>>>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.bool>, !p4hir.set<tuple<!b8i, !p4hir.bool>>
+        } to @p1::@accept
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@reject
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p1::@start
+  }
+
+  // CHECK-LABEL: p4hir.parser @p2
+  p4hir.parser @p2(%arg0: !b8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "x"}, %arg1: !b8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "y"}, %arg2: tuple<!b8i, !b8i> {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "w"})() {
+    %everything = p4hir.const #everything
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      %tuple = p4hir.tuple (%arg0, %arg1) : tuple<!b8i, !b8i>
+      // CHECK: p4hir.transition_select
+      p4hir.transition_select %tuple : tuple<!b8i, !b8i> {
+        p4hir.select_case {
+          // CHECK: %t0 = p4hir.tuple_extract %arg2[0] : tuple<!b8i, !b8i>
+          // CHECK: %t1 = p4hir.tuple_extract %arg2[1] : tuple<!b8i, !b8i>
+          %set = p4hir.set (%arg2) : !p4hir.set<tuple<!b8i, !b8i>>
+          p4hir.yield %set : !p4hir.set<tuple<!b8i, !b8i>>
+        } to @p2::@reject
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p2::@accept
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p2::@start
+  }
+
+  // CHECK-LABEL: p4hir.parser @p3
+  p4hir.parser @p3(%arg0: !b8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "x"}, %arg1: !b8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "y"}, %arg2: tuple<!b8i, !b8i> {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "w"})() {
+    %everything = p4hir.const #everything
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      // CHECK: %t0 = p4hir.tuple_extract %arg2[0] : tuple<!b8i, !b8i>
+      // CHECK: %t1 = p4hir.tuple_extract %arg2[1] : tuple<!b8i, !b8i>
+      // CHECK: p4hir.transition_select
+      p4hir.transition_select %arg2 : tuple<!b8i, !b8i> {
+        p4hir.select_case {
+          %tuple = p4hir.tuple (%arg0, %arg1) : tuple<!b8i, !b8i>
+          %set = p4hir.set (%tuple) : !p4hir.set<tuple<!b8i, !b8i>>
+          p4hir.yield %set : !p4hir.set<tuple<!b8i, !b8i>>
+        } to @p3::@reject
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p3::@accept
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p3::@start
+  }
+
+}

--- a/test/Transforms/Passes/simplify-select-replace-bools.mlir
+++ b/test/Transforms/Passes/simplify-select-replace-bools.mlir
@@ -1,0 +1,67 @@
+// RUN: p4mlir-opt --p4hir-simplify-select="flatten-tuples=false replace-bools=true replace-ranges=false concat-args=false" --canonicalize %s | FileCheck %s
+
+!b8i = !p4hir.bit<8>
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+#false = #p4hir.bool<false> : !p4hir.bool
+#true = #p4hir.bool<true> : !p4hir.bool
+#int1_b8i = #p4hir.int<1> : !b8i
+#int2_b8i = #p4hir.int<2> : !b8i
+#set_const_of_false = #p4hir.set<const : [#false]> : !p4hir.set<!p4hir.bool>
+#set_const_of_true = #p4hir.set<const : [#true]> : !p4hir.set<!p4hir.bool>
+#set_const_of_int1_b8i = #p4hir.set<const : [#int1_b8i]> : !p4hir.set<!b8i>
+#set_const_of_int2_b8i = #p4hir.set<const : [#int2_b8i]> : !p4hir.set<!b8i>
+
+// CHECK-LABEL: module
+module {
+  p4hir.parser @p1(%arg0: !p4hir.bool, %arg1: !b8i, %arg2: !p4hir.bool)() {
+    %set = p4hir.const #set_const_of_int2_b8i
+    %set_0 = p4hir.const #set_const_of_int1_b8i
+    %set_1 = p4hir.const #set_const_of_true
+    %set_2 = p4hir.const #set_const_of_false
+    %everything = p4hir.const #everything
+    %false = p4hir.const #false
+    %w = p4hir.variable ["w", init] : <!p4hir.bool>
+    p4hir.assign %false, %w : <!p4hir.bool>
+
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      // CHECK: p4hir.transition_select %{{.*}} : !b1i, !b8i, !b1i {
+      p4hir.transition_select %arg0, %arg1, %arg2 : !p4hir.bool, !b8i, !p4hir.bool {
+        p4hir.select_case {
+          // CHECK: p4hir.yield %{{.*}} : !p4hir.set<!b1i>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!b1i>
+          p4hir.yield %set_2, %everything, %set_1 : !p4hir.set<!p4hir.bool>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          %val = p4hir.read %w : <!p4hir.bool>
+          %set_3 = p4hir.set (%val) : !p4hir.set<!p4hir.bool>
+          %val_4 = p4hir.read %w : <!p4hir.bool>
+          %set_5 = p4hir.set (%val_4) : !p4hir.set<!p4hir.bool>
+          // CHECK: p4hir.yield %{{.*}} : !p4hir.set<!b1i>, !p4hir.set<!b8i>, !p4hir.set<!b1i>
+          p4hir.yield %set_3, %set_0, %set_5 : !p4hir.set<!p4hir.bool>, !p4hir.set<!b8i>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          %val = p4hir.read %w : <!p4hir.bool>
+          %set_3 = p4hir.set (%val) : !p4hir.set<!p4hir.bool>
+          // CHECK: p4hir.yield %{{.*}} : !p4hir.set<!b1i>, !p4hir.set<!b8i>, !p4hir.set<!b1i>
+          p4hir.yield %set_1, %set, %set_3 : !p4hir.set<!p4hir.bool>, !p4hir.set<!b8i>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          // CHECK: p4hir.yield %{{.*}} : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!b1i>
+          p4hir.yield %everything, %everything, %set_2 : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.bool>
+        } to @p1::@reject
+        p4hir.select_case {
+          // CHECK: p4hir.yield %{{.*}} : !p4hir.set<!p4hir.dontcare>
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@accept
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p1::@start
+  }
+}
+

--- a/test/Transforms/Passes/simplify-select-replace-ranges.mlir
+++ b/test/Transforms/Passes/simplify-select-replace-ranges.mlir
@@ -1,0 +1,67 @@
+// RUN: p4mlir-opt --p4hir-simplify-select="flatten-tuples=false replace-bools=false replace-ranges=true concat-args=false" --canonicalize %s | FileCheck %s
+
+!b8i = !p4hir.bit<8>
+!i8i = !p4hir.int<8>
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+#int0_b8i = #p4hir.int<0> : !b8i
+#int1_b8i = #p4hir.int<1> : !b8i
+#int1_i8i = #p4hir.int<1> : !i8i
+#int2_b8i = #p4hir.int<2> : !b8i
+#int3_b8i = #p4hir.int<3> : !b8i
+#int3_i8i = #p4hir.int<3> : !i8i
+#int8_b8i = #p4hir.int<8> : !b8i
+#int8_i8i = #p4hir.int<8> : !i8i
+#set_const_of_int8_b8i = #p4hir.set<const : [#int8_b8i]> : !p4hir.set<!b8i>
+#set_mask_of_int1_i8i_int1_i8i = #p4hir.set<mask : [#int1_i8i, #int1_i8i]> : !p4hir.set<!i8i>
+#set_range_of_int0_b8i_int3_b8i = #p4hir.set<range : [#int0_b8i, #int3_b8i]> : !p4hir.set<!b8i>
+#set_range_of_int1_b8i_int2_b8i = #p4hir.set<range : [#int1_b8i, #int2_b8i]> : !p4hir.set<!b8i>
+#set_range_of_int1_i8i_int3_i8i = #p4hir.set<range : [#int1_i8i, #int3_i8i]> : !p4hir.set<!i8i>
+#set_range_of_int3_i8i_int8_i8i = #p4hir.set<range : [#int3_i8i, #int8_i8i]> : !p4hir.set<!i8i>
+
+// CHECK-LABEL: module
+module {
+  p4hir.parser @p1(%arg0: !i8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "a"}, %arg1: !b8i {p4hir.dir = #p4hir<dir in>, p4hir.param_name = "b"})() {
+    // CHECK: %[[cst0:set.*]] = p4hir.const #set_mask_of_int0_b8i_int-4_b8i
+    // CHECK: %[[cst1:set.*]] = p4hir.const #set_mask_of_int1_b8i_int1_b8i
+    // CHECK: %[[cst2:set.*]] = p4hir.const #set_mask_of_int8_b8i_int-1_b8i
+    // CHECK: %[[cst3:set.*]] = p4hir.const #set_mask_of_int4_b8i_int-4_b8i
+    // CHECK: %[[cst4:set.*]] = p4hir.const #set_mask_of_int2_b8i_int-1_b8i
+    // CHECK: %[[cst5:set.*]] = p4hir.const #set_mask_of_int3_b8i_int-1_b8i
+    // CHECK: %[[cst6:set.*]] = p4hir.const #set_mask_of_int2_b8i_int-2_b8i
+    // CHECK: %[[cst7:set.*]] = p4hir.const #set_mask_of_int1_b8i_int-1_b8i
+    // CHECK: %[[cst8:set.*]] = p4hir.const #set_const_of_int8_b8i
+    %set = p4hir.const #set_range_of_int0_b8i_int3_b8i
+    %set_0 = p4hir.const #set_mask_of_int1_i8i_int1_i8i
+    %set_1 = p4hir.const #set_range_of_int1_b8i_int2_b8i
+    %set_2 = p4hir.const #set_range_of_int3_i8i_int8_i8i
+    %set_3 = p4hir.const #set_const_of_int8_b8i
+    %set_4 = p4hir.const #set_range_of_int1_i8i_int3_i8i
+    %everything = p4hir.const #everything
+
+    // CHECK-LABEL: p4hir.state @start
+    p4hir.state @start {
+      // CHECK: %[[cast:.*]] = p4hir.cast(%arg0 : !i8i) : !b8i
+      p4hir.transition_select %arg0, %arg1 : !i8i, !b8i {
+        p4hir.select_case {
+          p4hir.yield %set_4, %set_3 : !p4hir.set<!i8i>, !p4hir.set<!b8i>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %set_2, %set_1 : !p4hir.set<!i8i>, !p4hir.set<!b8i>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %set_0, %set : !p4hir.set<!i8i>, !p4hir.set<!b8i>
+        } to @p1::@reject
+        p4hir.select_case {
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @p1::@accept
+      }
+    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+    p4hir.state @reject {
+      p4hir.parser_reject
+    }
+    p4hir.transition to @p1::@start
+  }
+}

--- a/test/Translate/Parser/select.p4
+++ b/test/Translate/Parser/select.p4
@@ -77,14 +77,13 @@ parser p2(in bit<10> foo, out bool matches) {
 // Check more complex set product operations
 // CHECK-LABEL: p4hir.parser @p2
 // CHECK-LABEL:    p4hir.state @start {
-// CHECK:      p4hir.transition_select %{{.*}} : tuple<!b10i, !p4hir.bool> {
+// CHECK:      p4hir.transition_select %{{.*}} : !b10i, !p4hir.bool {
 // CHECK:        p4hir.select_case {
 // CHECK:          %[[c1_b10i:.*]] = p4hir.const #int1_b10i
 // CHECK:          %[[set:.*]] = p4hir.set (%[[c1_b10i]]) : !p4hir.set<!b10i>
 // CHECK:          %[[false:.*]] = p4hir.const #false
 // CHECK:          %[[set_0:.*]] = p4hir.set (%[[false]]) : !p4hir.set<!p4hir.bool>
-// CHECK:          %[[setproduct:.*]] = p4hir.set_product (%[[set]], %[[set_0]]) : !p4hir.set<tuple<!b10i, !p4hir.bool>>
-// CHECK:          p4hir.yield %[[setproduct]] : !p4hir.set<tuple<!b10i, !p4hir.bool>>
+// CHECK:          p4hir.yield %[[set]], %[[set_0]] : !p4hir.set<!b10i>, !p4hir.set<!p4hir.bool>
 // CHECK:        } to @p2::@drop
 // CHECK:        p4hir.select_case {
 // CHECK:          %[[c10_b10i:.*]] = p4hir.const #int10_b10i
@@ -92,22 +91,19 @@ parser p2(in bit<10> foo, out bool matches) {
 // CHECK:          %[[range:.*]] = p4hir.range(%[[c10_b10i]], %[[c20_b10i]]) : !p4hir.set<!b10i>
 // CHECK:          %[[true_0:.*]] = p4hir.const #true
 // CHECK:          %[[set:.*]] = p4hir.set (%true_0) : !p4hir.set<!p4hir.bool>
-// CHECK:          %[[setproduct:.*]] = p4hir.set_product (%[[range]], %[[set]]) : !p4hir.set<tuple<!b10i, !p4hir.bool>>
-// CHECK:          p4hir.yield %[[setproduct]] : !p4hir.set<tuple<!b10i, !p4hir.bool>>
+// CHECK:          p4hir.yield %[[range]], %[[set]] : !p4hir.set<!b10i>, !p4hir.set<!p4hir.bool>
 // CHECK:        } to @p2::@next
 // CHECK:        p4hir.select_case {
 // CHECK:          %[[c0_b10i:.*]] = p4hir.const #int0_b10i
 // CHECK:          %[[c0_b10i_0:.*]] = p4hir.const #int0_b10i
 // CHECK:          %[[mask:.*]] = p4hir.mask(%[[c0_b10i]], %[[c0_b10i_0]]) : !p4hir.set<!b10i>
 // CHECK:          %[[everything:.*]] = p4hir.const #everything
-// CHECK:          %[[setproduct:.*]] = p4hir.set_product (%[[mask]], %[[everything]]) : !p4hir.set<tuple<!b10i, !p4hir.dontcare>>
-// CHECK:          p4hir.yield %[[setproduct]] : !p4hir.set<tuple<!b10i, !p4hir.dontcare>>
+// CHECK:          p4hir.yield %[[mask]], %[[everything]] : !p4hir.set<!b10i>, !p4hir.set<!p4hir.dontcare>
 // CHECK:        } to @p2::@next
 // CHECK:        p4hir.select_case {
 // CHECK:          %[[everything:.*]] = p4hir.const #everything
 // CHECK:          %[[everything_0:.*]] = p4hir.const #everything
-// CHECK:          %[[setproduct:.*]] = p4hir.set_product (%[[everything]], %[[everything_0]]) : !p4hir.set<tuple<!p4hir.dontcare, !p4hir.dontcare>>
-// CHECK:          p4hir.yield %[[setproduct]] : !p4hir.set<tuple<!p4hir.dontcare, !p4hir.dontcare>>
+// CHECK:          p4hir.yield %[[everything]], %[[everything_0]] : !p4hir.set<!p4hir.dontcare>, !p4hir.set<!p4hir.dontcare>
 // CHECK:        } to @p2::@reject
 // CHECK:        p4hir.select_case {
 // CHECK:          %[[everything:.*]] = p4hir.const #everything

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -3016,16 +3016,16 @@ bool P4HIRConverter::preorder(const P4::IR::ParserState *state) {
 bool P4HIRConverter::preorder(const P4::IR::SelectExpression *select) {
     ConversionTracer trace("Converting ", select);
 
-    // Materialize value to select over. Select is always a ListExpression,
-    // even if it contains a single value. Lists ae lowered to tuples,
-    // however, single value cases are not single-value tuples. Unwrap
-    // single-value ListExpression down to the sole component.
-    const P4::IR::Expression *selectArg = select->select;
-    if (select->select->components.size() == 1) selectArg = select->select->components.front();
+    // Materialize values to select over. Select is always a ListExpression,
+    // even if it contains a single value. Unpack the top-level select tuple
+    // to its individual components for p4hir.transition_select.
+    const auto& comps = select->select->components;
+    llvm::SmallVector<mlir::Value, 4> operands;
+    for (const P4::IR::Node *comp : comps)
+        operands.push_back(convert(comp));
 
-    // Create select itself
     auto transitionSelectOp = builder.create<P4HIR::ParserTransitionSelectOp>(
-        getLoc(builder, select), convert(selectArg));
+        getLoc(builder, select), operands);
     mlir::Block &first = transitionSelectOp.getBody().emplaceBlock();
 
     mlir::OpBuilder::InsertionGuard guard(builder);
@@ -3040,7 +3040,6 @@ bool P4HIRConverter::preorder(const P4::IR::SelectExpression *select) {
             [&](mlir::OpBuilder &b, mlir::Location) {
                 const auto *keyset = selectCase->keyset;
                 auto endLoc = getEndLoc(builder, keyset);
-                mlir::Value keyVal;
 
                 // Type inference does not do proper type unification for the key,
                 // so we'd need to do this by ourselves
@@ -3055,26 +3054,17 @@ bool P4HIRConverter::preorder(const P4::IR::SelectExpression *select) {
                     return elVal;
                 };
 
-                auto isUniversalSet = [](mlir::Value val) {
-                    if (auto cst = mlir::dyn_cast<P4HIR::ConstOp>(val.getDefiningOp()))
-                        return mlir::isa<P4HIR::UniversalSetAttr>(cst.getValue());
-
-                    return false;
-                };
-
+                // Create a variadic yield expression from the keys in the keyset.
+                llvm::SmallVector<mlir::Value, 4> elements;
                 if (const auto *keyList = keyset->to<P4::IR::ListExpression>()) {
-                    // Set product
-                    llvm::SmallVector<mlir::Value, 4> elements;
                     for (const auto *element : keyList->components)
                         elements.push_back(convertElement(element));
-                    // Treat product consisting entirely of universal sets as default case
-                    hasDefaultCase |= llvm::all_of(elements, isUniversalSet);
-                    keyVal = b.create<P4HIR::SetProductOp>(endLoc, elements);
                 } else {
-                    keyVal = convertElement(keyset);
-                    hasDefaultCase |= isUniversalSet(keyVal);
+                    elements.push_back(convertElement(keyset));
                 }
-                b.create<P4HIR::YieldOp>(endLoc, keyVal);
+
+                hasDefaultCase |= llvm::all_of(elements, P4HIR::isUniversalSetValue);
+                b.create<P4HIR::YieldOp>(endLoc, elements);
             },
             getQualifiedSymbolRef(nextState->name.string_view()));
     }


### PR DESCRIPTION
This PR implements the various transition_select optimizations from ticket #204.

Four of the five transformations (`SimplifySelectList` / `ReplaceSelectRange` / `RemoveSelectBooleans` / `SingleArgumentSelect`) are implemented as patterns of a new `SimplifySelect` optimization pass, while the equivalent of `SimplifySelectCases` is implemented as `ParserTransitionSelectOp` canonicalizations.

To aid implementing these optimizations and also simplify the IR, there is an initial commit that  makes `p4hir.transition_select` and the corresponding yield statements have variadic arguments. This was done because having either a single argument or a tuple of arguments and set products made all passes more complicated and required code duplication to handle one vs many arguments.

There is also an additional commit that refactors `CastOp` constant folding and fixes various signedness bugs around it.