### PR TITLE
Fix VariableOp::canonicalize

### DIFF
--- a/test/Transforms/Folds/variable.mlir
+++ b/test/Transforms/Folds/variable.mlir
@@ -1,5 +1,6 @@
 // RUN: p4mlir-opt --canonicalize %s | FileCheck %s
 
+!b1i = !p4hir.bit<1>
 !i32i = !p4hir.int<32>
 !T = !p4hir.struct<"T", t1: !i32i, t2: !i32i>
 
@@ -10,16 +11,36 @@
 module {
   p4hir.func @blackhole(!i32i)
 
-  %t = p4hir.const ["t"] #p4hir.aggregate<[#int10_i32i, #int20_i32i]> : !T
+  // CHECK-LABEL: p4hir.func @test_var_elim
+  p4hir.func @test_var_elim() {
+    %t = p4hir.const ["t"] #p4hir.aggregate<[#int10_i32i, #int20_i32i]> : !T
 
-  %var = p4hir.variable ["v"] : <!T>
-  p4hir.assign %t, %var : <!T>
+    %var = p4hir.variable ["v"] : <!T>
+    p4hir.assign %t, %var : <!T>
 
-  %struct = p4hir.read %var : <!T>
-  %t11 = p4hir.struct_extract %struct["t1"] : !T
+    %struct = p4hir.read %var : <!T>
+    %t11 = p4hir.struct_extract %struct["t1"] : !T
 
-  // This all just simplifies down to constant
-  // CHECK: %[[c10_i32i:.*]] = p4hir.const #int10_i32i
-  // CHECK: p4hir.call @blackhole (%[[c10_i32i]])
-  p4hir.call @blackhole(%t11) : (!i32i) -> ()
+    // This all just simplifies down to constant
+    // CHECK: %[[c10_i32i:.*]] = p4hir.const #int10_i32i
+    // CHECK: p4hir.call @blackhole (%[[c10_i32i]])
+    p4hir.call @blackhole(%t11) : (!i32i) -> ()
+
+    p4hir.return
+  }
+
+  // CHECK-LABEL: p4hir.func @test_read_before_write
+  p4hir.func @test_read_before_write() {
+    // Check that we don't crash.
+    %a = p4hir.variable ["a"] : <!b1i>
+    %d = p4hir.variable ["d"] : <!p4hir.bool>
+    %val = p4hir.read %d : <!p4hir.bool>
+    %cast = p4hir.cast(%val : !p4hir.bool) : !b1i
+    p4hir.assign %cast, %a : <!b1i>
+    %val_0 = p4hir.read %a : <!b1i>
+    %cast_1 = p4hir.cast(%val_0 : !b1i) : !p4hir.bool
+    p4hir.assign %cast_1, %d : <!p4hir.bool>
+
+    p4hir.return
+  }
 }


### PR DESCRIPTION
We need to check if the reads come after the respective write In `VariableOp::canonicalize` because otherwise we may use values before their definition. This issue triggered with `bool_cast.p4` from `p4_16_samples` where this mlir code:

```
!b1i = !p4hir.bit<1>
module {
  p4hir.control @SetAndFwd()() {
    p4hir.control_apply {
      %a = p4hir.variable ["a"] : <!b1i>
      %d = p4hir.variable ["d"] : <!p4hir.bool>
      %val = p4hir.read %d : <!p4hir.bool>
      %cast = p4hir.cast(%val : !p4hir.bool) : !b1i
      p4hir.assign %cast, %a : <!b1i>
      %val_0 = p4hir.read %a : <!b1i>
      %cast_1 = p4hir.cast(%val_0 : !b1i) : !p4hir.bool
      p4hir.assign %cast_1, %d : <!p4hir.bool>
    }
  }
}
```

would be rewritten as 

```
"p4hir.control"() <{applyType = !p4hir.func<()>, ctorType = !p4hir.ctor<!p4hir.control<"SetAndFwd", ()> ()>, sym_name = "SetAndFwd"}> ({
  "p4hir.control_apply"() ({
    %0 = "p4hir.cast"(%1) : (!p4hir.bool) -> !p4hir.bit<1>
    %1 = "p4hir.cast"(%0) : (!p4hir.bit<1>) -> !p4hir.bool
  }) : () -> ()
}) {sym_visibility = "public"} : () -> ()
```

and crash the compiler.

I've also made it so that the variable definition can be in a block other than the reads/writes.