### PR TITLE
Fix translator crash with zero-width variables

### DIFF
--- a/test/Translate/Ops/variables.p4
+++ b/test/Translate/Ops/variables.p4
@@ -87,3 +87,10 @@ action init_with_cast() {
     int<8> b = (int<8>)a;
     bit<8> c = (bit<8>)b;
 }
+
+// CHECK-LABEL:   p4hir.func action @check_zero_width_int
+// Check that we don't crash.
+
+action check_zero_width_int() {
+    bit<0> tmp = 1;
+}

--- a/tools/p4mlir-translate/translate.cpp
+++ b/tools/p4mlir-translate/translate.cpp
@@ -75,12 +75,12 @@ mlir::Location getEndLoc(mlir::OpBuilder &builder, const P4::IR::Node *node) {
         end.getColumnNumber());
 }
 
-mlir::APInt toAPInt(const P4::big_int &value, unsigned bitWidth = 0) {
+mlir::APInt toAPInt(const P4::big_int &value, unsigned bitWidth = UINT_MAX) {
     std::vector<uint64_t> valueBits;
     // Export absolute value into 64-bit unsigned values, most significant bit last
     export_bits(value, std::back_inserter(valueBits), 64, false);
 
-    if (!bitWidth) bitWidth = valueBits.size() * sizeof(valueBits[0]) * CHAR_BIT;
+    if (bitWidth == UINT_MAX) bitWidth = valueBits.size() * sizeof(valueBits[0]) * CHAR_BIT;
 
     mlir::APInt apValue(bitWidth, valueBits);
     if (value < 0) apValue.negate();


### PR DESCRIPTION
The default value of 0 on translator `toAPInt` is used as a sentinel but can also be a legal input for zero-width int types.
Fix by using a different sentinel value.