### PR TITLE
Add folding and canonicalization patterns for BinOp, CmpOp, SliceOp

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/CMakeLists.txt
+++ b/include/p4mlir/Dialect/P4HIR/CMakeLists.txt
@@ -5,6 +5,7 @@ mlir_tablegen(P4HIR_Ops.h.inc -gen-op-decls)
 mlir_tablegen(P4HIR_Ops.cpp.inc -gen-op-defs)
 mlir_tablegen(P4HIR_Types.h.inc -gen-typedef-decls -typedefs-dialect=p4hir)
 mlir_tablegen(P4HIR_Types.cpp.inc -gen-typedef-defs -typedefs-dialect=p4hir)
+mlir_tablegen(P4HIR_Patterns.inc -gen-rewriters)
 add_public_tablegen_target(P4MLIR_P4HIR_IncGen)
 add_dependencies(mlir-headers P4MLIR_P4HIR_IncGen)
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR.td
@@ -6,5 +6,6 @@ include "p4mlir/Dialect/P4HIR/P4HIR_Attrs.td"
 include "p4mlir/Dialect/P4HIR/P4HIR_Ops.td"
 include "p4mlir/Dialect/P4HIR/P4HIR_Types.td"
 include "p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.td"
+include "p4mlir/Dialect/P4HIR/P4HIR_Patterns.td"
 
 #endif // P4MLIR_DIALECT_P4HIR_P4HIR_TD

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Attrs.h
@@ -5,8 +5,16 @@
 // order to propagate pragma further on
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
+#include <optional>
+
+#include "llvm/ADT/APSInt.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Types.h"
+
+namespace P4::P4MLIR::P4HIR {
+std::optional<llvm::APSInt> getConstantInt(mlir::Attribute attr);
+mlir::TypedAttr foldConstantCast(mlir::Type destType, mlir::Attribute srcAttr);
+}  // namespace  P4::P4MLIR::P4HIR
 
 namespace P4::P4MLIR::P4HIR::detail {
 struct IntAttrStorage : public ::mlir::AttributeStorage {

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -507,6 +507,7 @@ def CmpOp : P4HIR_Op<"cmp",
 
   // Already covered by the traits
   let hasVerifier = 0;
+  let hasFolder = 1;
 }
 
 def ScopeOp : P4HIR_Op<"scope", [

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -346,6 +346,10 @@ def BinOp : P4HIR_Op<"binop", [Pure,
   let assemblyFormat = [{
     `(` $kind `,` $lhs `,` $rhs  `)` `:` type($lhs) attr-dict
   }];
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def ConcatOp : P4HIR_Op<"concat", [Pure]> {

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -343,6 +343,15 @@ def BinOp : P4HIR_Op<"binop", [Pure,
   let arguments = (ins Arg<BinOpKind, "binop kind">:$kind,
                        AnyIntP4Type:$lhs, AnyIntP4Type:$rhs);
 
+  let extraClassDeclaration = [{
+    bool isCommutative() {
+      auto kind = getKind();
+      return (kind == P4HIR::BinOpKind::Add) || (kind == P4HIR::BinOpKind::AddSat) ||
+             (kind == P4HIR::BinOpKind::Mul) || (kind == P4HIR::BinOpKind::And) ||
+             (kind == P4HIR::BinOpKind::Or) || (kind == P4HIR::BinOpKind::Xor);
+    }
+  }];
+
   let assemblyFormat = [{
     `(` $kind `,` $lhs `,` $rhs  `)` `:` type($lhs) attr-dict
   }];

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1187,6 +1187,7 @@ def SliceOp : P4HIR_Op<"slice",
   let assemblyFormat = [{
     $input`[`$highBit `:` $lowBit`]` attr-dict `:` type($input) `->` type($result)
   }];
+  let hasFolder = 1;
   let hasVerifier = 1;
 }
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Patterns.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Patterns.td
@@ -13,7 +13,7 @@ def SubIntAttrs : NativeCodeCall<"subIntegerAttrs($_builder, $0, $1, $2)">;
 def CreateConstOp : NativeCodeCall<"$_builder.create<P4HIR::ConstOp>($_loc, $0)">;
 
 class HasValueConstraint<int value> : Constraint<
-  CPred<"isIntegerAttr($0, " # value # ")">,
+  CPred<"isIntegerValue($0, " # value # ")">,
   "operand has value " # value
 >;
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Patterns.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Patterns.td
@@ -1,0 +1,140 @@
+#ifndef P4MLIR_DIALECT_P4HIR_P4HIR_PATTERNS_TD
+#define P4MLIR_DIALECT_P4HIR_P4HIR_PATTERNS_TD
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/PatternBase.td"
+include "p4mlir/Dialect/P4HIR/P4HIR_Attrs.td"
+include "p4mlir/Dialect/P4HIR/P4HIR_Ops.td"
+include "p4mlir/Dialect/P4HIR/P4HIR_Types.td"
+
+def AddIntAttrs : NativeCodeCall<"addIntegerAttrs($_builder, $0, $1, $2)">;
+def SubIntAttrs : NativeCodeCall<"subIntegerAttrs($_builder, $0, $1, $2)">;
+
+def CreateConstOp : NativeCodeCall<"$_builder.create<P4HIR::ConstOp>($_loc, $0)">;
+
+class HasValueConstraint<int value> : Constraint<
+  CPred<"isIntegerAttr($0, " # value # ")">,
+  "operand has value " # value
+>;
+
+// add(add(x, c0), c1) -> add(x, c0 + c1)
+def AddAddCst : Pat<
+  (BinOp:$res BinOpKind_Add,
+    (BinOp BinOpKind_Add, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Add, $x, (CreateConstOp (AddIntAttrs $res, $c0, $c1)))
+>;
+
+// sub(add(x, c0), c1) -> add(x, c0 - c1)
+def SubAddCst : Pat<
+  (BinOp:$res BinOpKind_Sub,
+    (BinOp BinOpKind_Add, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Add, $x, (CreateConstOp (SubIntAttrs $res, $c0, $c1)))
+>;
+
+// add(sub(x, c0), c1) -> add(x, c1 - c0)
+def AddSubCst : Pat<
+  (BinOp:$res BinOpKind_Add,
+    (BinOp BinOpKind_Sub, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Add, $x, (CreateConstOp (SubIntAttrs $res, $c1, $c0)))
+>;
+
+// sub(sub(x, c0), c1) -> sub(x, c0 + c1)
+def SubSubCst : Pat<
+  (BinOp:$res BinOpKind_Sub,
+    (BinOp BinOpKind_Sub, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Sub, $x, (CreateConstOp (AddIntAttrs $res, $c0, $c1)))
+>;
+
+// add(sub(c0, x), c1) -> sub(c0 + c1, x)
+def AddSubLhsCst : Pat<
+  (BinOp:$res BinOpKind_Add,
+    (BinOp BinOpKind_Sub, (ConstantLikeMatcher AnyAttr:$c0), $x),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Sub, (CreateConstOp (AddIntAttrs $res, $c0, $c1)), $x)
+>;
+
+// sub(sub(c0, x), c1) -> sub(c0 - c1, x)
+def SubSubLhsCst : Pat<
+  (BinOp:$res BinOpKind_Sub,
+    (BinOp BinOpKind_Sub, (ConstantLikeMatcher AnyAttr:$c0), $x),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Sub, (CreateConstOp (SubIntAttrs $res, $c0, $c1)), $x)
+>;
+
+// sub(c0, sub(x, c1)) -> sub(c0 + c1, x)
+def SubRhsSubCst : Pat<
+  (BinOp:$res BinOpKind_Sub,
+    (ConstantLikeMatcher AnyAttr:$c0),
+    (BinOp BinOpKind_Sub, $x, (ConstantLikeMatcher AnyAttr:$c1))),
+  (BinOp BinOpKind_Sub, (CreateConstOp (AddIntAttrs $res, $c0, $c1)), $x)
+>;
+
+// sub(c0, sub(c1, x)) -> add(x, c0 - c1)
+def SubRhsSubLhsCst : Pat<
+  (BinOp:$res BinOpKind_Sub,
+    (ConstantLikeMatcher AnyAttr:$c0),
+    (BinOp BinOpKind_Sub, (ConstantLikeMatcher AnyAttr:$c1), $x)),
+  (BinOp BinOpKind_Add, $x, (CreateConstOp (SubIntAttrs $res, $c0, $c1)))
+>;
+
+// add(neg(x), y) -> sub(y, x)
+def AddNeg : Pat<
+  (BinOp:$res BinOpKind_Add, (UnaryOp UnaryOpKind_Neg, $x), $y),
+  (BinOp BinOpKind_Sub, $y, $x)
+>;
+
+// add(x, neg(y)) -> sub(x, y)
+def AddRhsNeg : Pat<
+  (BinOp:$res BinOpKind_Add, $x, (UnaryOp UnaryOpKind_Neg, $y)),
+  (BinOp BinOpKind_Sub, $x, $y)
+>;
+
+// sub(x, neg(y)) -> add(x, y)
+def SubRhsNeg : Pat<
+  (BinOp:$res BinOpKind_Sub, $x, (UnaryOp UnaryOpKind_Neg, $y)),
+  (BinOp BinOpKind_Add, $x, $y)
+>;
+
+// mul(x, -1) -> neg(x)
+def MulToNeg : Pat<
+  (BinOp:$res BinOpKind_Mul, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+  (UnaryOp UnaryOpKind_Neg, $x),
+  [(HasValueConstraint<-1> $c0)]
+>;
+
+// sub(0, x) -> neg(x)
+def SubToNeg : Pat<
+  (BinOp:$res BinOpKind_Sub, (ConstantLikeMatcher AnyAttr:$c0), $x),
+  (UnaryOp UnaryOpKind_Neg, $x),
+  [(HasValueConstraint<0> $c0)]
+>;
+
+// sub_sat(0, x) -> neg(x)
+def SubSatToNeg : Pat<
+  (BinOp:$res BinOpKind_SubSat, (ConstantLikeMatcher AnyAttr:$c0), $x),
+  (UnaryOp UnaryOpKind_Neg, $x),
+  [(HasValueConstraint<0> $c0)]
+>;
+
+// add(cmpl(x), 1) -> neg(x)
+def AddCmplToNeg : Pat<
+  (BinOp:$res BinOpKind_Add,
+    (UnaryOp UnaryOpKind_Cmpl, $x),
+    (ConstantLikeMatcher AnyAttr:$c0)),
+  (UnaryOp UnaryOpKind_Neg, $x),
+  [(HasValueConstraint<1> $c0)]
+>;
+
+// mul(mul(x, c0), c1) -> mul(x, c0 + c1)
+def MulMulCst : Pat<
+  (BinOp:$res BinOpKind_Mul,
+    (BinOp BinOpKind_Mul, $x, (ConstantLikeMatcher AnyAttr:$c0)),
+    (ConstantLikeMatcher AnyAttr:$c1)),
+  (BinOp BinOpKind_Mul, $x, (CreateConstOp (AddIntAttrs $res, $c0, $c1)))
+>;
+
+#endif // P4MLIR_DIALECT_P4HIR_P4HIR_PATTERNS_TD

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -1835,6 +1835,16 @@ LogicalResult P4HIR::SliceOp::verify() {
     return success();
 }
 
+OpFoldResult P4HIR::SliceOp::fold(FoldAdaptor adaptor) {
+    if (adaptor.getInput()) {
+        auto input = P4HIR::getConstantInt(adaptor.getInput()).value();
+        auto sliceVal = input.extractBits((getHighBit() - getLowBit() + 1), getLowBit());
+        return P4HIR::IntAttr::get(getContext(), getType(), sliceVal);
+    }
+
+    return {};
+}
+
 LogicalResult P4HIR::SliceRefOp::verify() {
     auto resultType = getResult().getType();
     auto sourceType = llvm::cast<P4HIR::ReferenceType>(getInput().getType()).getObjectType();

--- a/test/Dialect/P4HIR/binop.mlir
+++ b/test/Dialect/P4HIR/binop.mlir
@@ -46,9 +46,4 @@ module {
   %mod_int = p4hir.binop(mod, %lhs_int, %rhs_int) : !int
   %add_int = p4hir.binop(add, %lhs_int, %rhs_int) : !int
   %sub_int = p4hir.binop(sub, %lhs_int, %rhs_int) : !int
-  %sadd_int = p4hir.binop(sadd, %lhs_int, %rhs_int) : !int
-  %ssub_int = p4hir.binop(ssub, %lhs_int, %rhs_int) : !int
-  %and_int = p4hir.binop(and, %lhs_int, %rhs_int) : !int
-  %or_int = p4hir.binop(or, %lhs_int, %rhs_int) : !int
-  %xor_int = p4hir.binop(xor, %lhs_int, %rhs_int) : !int
 }

--- a/test/Transforms/Folds/binop.mlir
+++ b/test/Transforms/Folds/binop.mlir
@@ -1,0 +1,256 @@
+// RUN: p4mlir-opt --canonicalize %s | FileCheck %s
+
+!i32i = !p4hir.int<32>
+!b32i = !p4hir.bit<32>
+!int = !p4hir.infint
+
+#int0_i32i = #p4hir.int<0> : !i32i
+#int1_i32i = #p4hir.int<1> : !i32i
+#int5_i32i = #p4hir.int<5> : !i32i
+#int10_i32i = #p4hir.int<10> : !i32i
+#int15_i32i = #p4hir.int<15> : !i32i
+#int50_i32i = #p4hir.int<50> : !i32i
+#int0_b32i = #p4hir.int<0> : !b32i
+#int-1_b32i = #p4hir.int<4294967295> : !b32i  // 0xFFFFFFFF for 32-bit
+
+// CHECK-LABEL: module
+module {
+  p4hir.func @blackhole_i32i(!i32i)
+  p4hir.func @blackhole_b32i(!b32i)
+  p4hir.func @blackhole_int(!int)
+
+  // CHECK: p4hir.func @test(%[[signed:.*]]: !i32i, %[[unsigned:.*]]: !b32i)
+  p4hir.func @test(%arg_i32i : !i32i, %arg_b32i : !b32i) {
+    // CHECK-DAG: %[[c0_i32i:.*]] = p4hir.const #int0_i32i
+    // CHECK-DAG: %[[c1_i32i:.*]] = p4hir.const #int1_i32i
+    // CHECK-DAG: %[[c5_i32i:.*]] = p4hir.const #int5_i32i
+    // CHECK-DAG: %[[c10_i32i:.*]] = p4hir.const #int10_i32i
+    // CHECK-DAG: %[[c15_i32i:.*]] = p4hir.const #int15_i32i
+    // CHECK-DAG: %[[c50_i32i:.*]] = p4hir.const #int50_i32i
+    // CHECK-DAG: %[[c0_b32i:.*]] = p4hir.const #int0_b32i
+    // CHECK-DAG: %[[cones_b32i:.*]] = p4hir.const #int-1_b32i
+
+    // CHECK-DAG: %[[cM4_infint:.*]] = p4hir.const #int-4_infint
+    // CHECK-DAG: %[[cM255_infint:.*]] = p4hir.const #int-255_infint
+    // CHECK-DAG: %[[cM256_infint:.*]] = p4hir.const #int-256_infint
+    // CHECK-DAG: %[[c510_infint:.*]] = p4hir.const #int510_infint
+    // CHECK-DAG: %[[c0_infint:.*]] = p4hir.const #int0_infint
+    // CHECK-DAG: %[[c2_infint:.*]] = p4hir.const #int2_infint
+    // CHECK-DAG: %[[c3_infint:.*]] = p4hir.const #int3_infint
+    // CHECK-DAG: %[[c116_infint:.*]] = p4hir.const #int116_infint
+    // CHECK-DAG: %[[c178_infint:.*]] = p4hir.const #int178_infint
+    // CHECK-DAG: %[[c65025_infint:.*]] = p4hir.const #int65025_infint
+
+    %c0_i32i = p4hir.const #int0_i32i
+    %c1_i32i = p4hir.const #int1_i32i
+    %c5_i32i = p4hir.const #int5_i32i
+    %c10_i32i = p4hir.const #int10_i32i
+    %c15_i32i = p4hir.const #int15_i32i
+    %c50_i32i = p4hir.const #int50_i32i
+    %c0_b32i = p4hir.const #int0_b32i
+    %cones_b32i = p4hir.const #int-1_b32i
+
+    %c255_int = p4hir.const #p4hir.int<255> : !int
+    %c45506_int = p4hir.const #p4hir.int<45506> : !int
+    %cMinus1_int = p4hir.const #p4hir.int<-1> : !int
+    %cMinus3_int = p4hir.const #p4hir.int<-3> : !int
+
+    // ADD
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res1 = p4hir.binop(add, %arg_i32i, %c0_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res1) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res2 = p4hir.binop(add, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res2) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c15_i32i]])
+    %res3 = p4hir.binop(add, %c5_i32i, %c10_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res3) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res4 = p4hir.binop(add, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res4) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[cM4_infint]])
+    %res5 = p4hir.binop(add, %cMinus1_int, %cMinus3_int) : !int
+    p4hir.call @blackhole_int(%res5) : (!int) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c510_infint]])
+    %res6 = p4hir.binop(add, %c255_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res6) : (!int) -> ()
+
+    // SADD
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res7 = p4hir.binop(sadd, %arg_i32i, %c0_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res7) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res8 = p4hir.binop(sadd, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res8) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c15_i32i]])
+    %res9 = p4hir.binop(sadd, %c5_i32i, %c10_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res9) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res10 = p4hir.binop(sadd, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res10) : (!b32i) -> ()
+
+    // SUB
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res11 = p4hir.binop(sub, %arg_i32i, %c0_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res11) : (!i32i) -> ()
+
+    // CHECK: %[[minus:.*]] = p4hir.unary(minus, %[[signed]])
+    // CHECK: p4hir.call @blackhole_i32i (%[[minus]])
+    %res12 = p4hir.binop(sub, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res12) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res13 = p4hir.binop(sub, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res13) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c2_infint]])
+    %res14 = p4hir.binop(sub, %cMinus1_int, %cMinus3_int) : !int
+    p4hir.call @blackhole_int(%res14) : (!int) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[cM256_infint]])
+    %res15 = p4hir.binop(sub, %cMinus1_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res15) : (!int) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c0_infint]])
+    %res16 = p4hir.binop(sub, %c255_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res16) : (!int) -> ()
+
+    // SSUB
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res17 = p4hir.binop(ssub, %arg_i32i, %c0_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res17) : (!i32i) -> ()
+
+    // CHECK: %[[minus:.*]] = p4hir.unary(minus, %[[signed]])
+    // CHECK: p4hir.call @blackhole_i32i (%[[minus]])
+    %res18 = p4hir.binop(ssub, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res18) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res19 = p4hir.binop(sub, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res19) : (!b32i) -> ()
+
+    // MUL
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res20 = p4hir.binop(mul, %arg_i32i, %c1_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res20) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c0_i32i]])
+    %res21 = p4hir.binop(mul, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res21) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c50_i32i]])
+    %res22 = p4hir.binop(mul, %c5_i32i, %c10_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res22) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[c0_b32i]])
+    %res23 = p4hir.binop(mul, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res23) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c3_infint]])
+    %res24 = p4hir.binop(mul, %cMinus1_int, %cMinus3_int) : !int
+    p4hir.call @blackhole_int(%res24) : (!int) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[cM255_infint]])
+    %res25 = p4hir.binop(mul, %cMinus1_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res25) : (!int) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c65025_infint]])
+    %res26 = p4hir.binop(mul, %c255_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res26) : (!int) -> ()
+
+    // DIV
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res27 = p4hir.binop(div, %arg_i32i, %c1_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res27) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c0_i32i]])
+    %res28 = p4hir.binop(div, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res28) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[c0_b32i]])
+    %res29 = p4hir.binop(div, %c0_b32i, %arg_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res29) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c178_infint]])
+    %res30 = p4hir.binop(div, %c45506_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res30) : (!int) -> ()
+
+    // MOD
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c0_i32i]])
+    %res31 = p4hir.binop(mod, %arg_i32i, %c1_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res31) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c0_i32i]])
+    %res32 = p4hir.binop(mod, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res32) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[c0_b32i]])
+    %res33 = p4hir.binop(div, %c0_b32i, %arg_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res33) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_int (%[[c116_infint]])
+    %res34 = p4hir.binop(mod, %c45506_int, %c255_int) : !int
+    p4hir.call @blackhole_int(%res34) : (!int) -> ()
+
+    // OR
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[signed]])
+    %res35 = p4hir.binop(or, %c0_i32i, %arg_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res35) : (!i32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[cones_b32i]])
+    %res36 = p4hir.binop(or, %arg_b32i, %cones_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res36) : (!b32i) -> ()
+
+    // AND
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[c0_b32i]])
+    %res37 = p4hir.binop(and, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res37) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res38 = p4hir.binop(and, %arg_b32i, %cones_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res38) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c0_i32i]])
+    %res39 = p4hir.binop(and, %c5_i32i, %c10_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res39) : (!i32i) -> ()
+
+    // XOR
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res40 = p4hir.binop(xor, %arg_b32i, %c0_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res40) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b32i (%[[unsigned]])
+    %res41 = p4hir.binop(xor, %c0_b32i, %arg_b32i) : !b32i
+    p4hir.call @blackhole_b32i(%res41) : (!b32i) -> ()
+
+    // CHECK: p4hir.call @blackhole_i32i (%[[c15_i32i]])
+    %res42 = p4hir.binop(xor, %c5_i32i, %c10_i32i) : !i32i
+    p4hir.call @blackhole_i32i(%res42) : (!i32i) -> ()
+
+    p4hir.call @blackhole_i32i(%c0_i32i) : (!i32i) -> ()
+    p4hir.call @blackhole_i32i(%c1_i32i) : (!i32i) -> ()
+    p4hir.call @blackhole_i32i(%c5_i32i) : (!i32i) -> ()
+    p4hir.call @blackhole_i32i(%c10_i32i) : (!i32i) -> ()
+    p4hir.call @blackhole_b32i(%c0_b32i) : (!b32i) -> ()
+    p4hir.call @blackhole_b32i(%cones_b32i) : (!b32i) -> ()
+    p4hir.return
+  }
+}

--- a/test/Transforms/Folds/cast.mlir
+++ b/test/Transforms/Folds/cast.mlir
@@ -1,6 +1,7 @@
 // RUN: p4mlir-opt --canonicalize %s | FileCheck %s
 
 !i8i = !p4hir.int<8>
+!i16i = !p4hir.int<16>
 !b8i = !p4hir.bit<8>
 !infint = !p4hir.infint
 #false = #p4hir.bool<false> : !p4hir.bool
@@ -20,12 +21,14 @@
 
 // CHECK-LABEL: module
 module {
+  // CHECK: %[[cm128_i16i:.*]] = p4hir.const #int-128_i16i
   // CHECK: %[[cm42_i8i:.*]] = p4hir.const #int-42_i8i
   // CHECK: %[[c1_i8i:.*]] = p4hir.const #int1_i8i
   // CHECK: %[[c0_i8i:.*]] = p4hir.const #int0_i8i
   // CHECK: %[[cm128_i8i:.*]] = p4hir.const #int-128_i8i
   
-  p4hir.func @blackhole(!i8i)
+  p4hir.func @blackhole_i8i(!i8i)
+  p4hir.func @blackhole_i16i(!i16i)
 
   %c-128_i8i = p4hir.const #int-128_i8i
   %false = p4hir.const #false
@@ -34,27 +37,33 @@ module {
   %c-42 = p4hir.const #int-42_infint
 
   %cast1 = p4hir.cast(%c-128_i8i : !i8i) : !i8i
-  p4hir.call @blackhole(%cast1) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast1) : (!i8i) -> ()
 
-  // CHECK: p4hir.call @blackhole (%[[cm128_i8i]]) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm128_i8i]]) : (!i8i) -> ()
   
   %cast2 = p4hir.cast(%false : !p4hir.bool) : !i8i
-  p4hir.call @blackhole(%cast2) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%c0_i8i) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast2) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%c0_i8i) : (!i8i) -> ()
   
   %cast3 = p4hir.cast(%true : !p4hir.bool) : !i8i
-  p4hir.call @blackhole(%cast3) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%[[c1_i8i]]) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast3) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[c1_i8i]]) : (!i8i) -> ()
 
   %cast4 = p4hir.cast(%c-42 : !p4hir.infint) : !i8i
-  p4hir.call @blackhole(%cast4) : (!i8i) -> ()
-  // CHECK: p4hir.call @blackhole (%[[cm42_i8i]]) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast4) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm42_i8i]]) : (!i8i) -> ()
 
   %castA = p4hir.cast(%cast1 : !i8i) : !b8i
   %castB = p4hir.cast(%castA : !b8i) : !i8i
-  p4hir.call @blackhole(%castB) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%castB) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[cm128_i8i]]) : (!i8i) -> ()
 
   %Suits_Clubs = p4hir.const #Suits_Clubs
   %cast5 = p4hir.cast(%Suits_Clubs : !SuitsSerializable) : !i8i
-  p4hir.call @blackhole(%cast5) : (!i8i) -> ()
+  p4hir.call @blackhole_i8i(%cast5) : (!i8i) -> ()
+  // CHECK: p4hir.call @blackhole_i8i (%[[c1_i8i]]) : (!i8i) -> ()
+
+  %cast6 = p4hir.cast(%c-128_i8i : !i8i) : !i16i
+  p4hir.call @blackhole_i16i(%cast6) : (!i16i) -> ()
+  // CHECK: p4hir.call @blackhole_i16i (%[[cm128_i16i]]) : (!i16i) -> ()
 }

--- a/test/Transforms/Folds/cmpop.mlir
+++ b/test/Transforms/Folds/cmpop.mlir
@@ -1,0 +1,169 @@
+// RUN: p4mlir-opt --canonicalize %s | FileCheck %s
+
+!i32i = !p4hir.int<32>
+!b32i = !p4hir.bit<32>
+!int = !p4hir.infint
+
+#int5_i32i = #p4hir.int<5> : !i32i
+#int10_i32i = #p4hir.int<10> : !i32i
+#int15_i32i = #p4hir.int<15> : !i32i
+#int0_b32i = #p4hir.int<0> : !b32i
+
+// CHECK-LABEL: module
+module {
+  p4hir.func @blackhole_bool(!p4hir.bool)
+  p4hir.func @blackhole_b32i(!b32i)
+  p4hir.func @blackhole_int(!int)
+
+  // CHECK: p4hir.func @test(%[[ARG:.*]]: !i32i)
+  p4hir.func @test(%arg_i32i : !i32i) {
+    // CHECK: %[[c5_i32i:.*]] = p4hir.const #int5_i32i
+    %c5_i32i = p4hir.const #int5_i32i
+    %c10_i32i = p4hir.const #int10_i32i
+    %c15_i32i = p4hir.const #int15_i32i
+    %c0_b32i = p4hir.const #int0_b32i
+
+    %c255_int = p4hir.const #p4hir.int<255> : !int
+    %c45506_int = p4hir.const #p4hir.int<45506> : !int
+
+    // EQ
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res1_eq = p4hir.cmp(eq, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_eq) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[EQ:.*]] = p4hir.cmp(eq, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[EQ]])
+    %res2_eq = p4hir.cmp(eq, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_eq) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res3_eq = p4hir.cmp(eq, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_eq) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res4_eq = p4hir.cmp(eq, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_eq) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res5_eq = p4hir.cmp(eq, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_eq) : (!p4hir.bool) -> ()
+
+    // NE
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res1_ne = p4hir.cmp(ne, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_ne) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[NE:.*]] = p4hir.cmp(ne, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[NE]])
+    %res2_ne = p4hir.cmp(ne, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_ne) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res3_ne = p4hir.cmp(ne, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_ne) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res4_ne = p4hir.cmp(ne, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_ne) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res5_ne = p4hir.cmp(ne, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_ne) : (!p4hir.bool) -> ()
+
+    // LT
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res1_lt = p4hir.cmp(lt, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_lt) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[GT:.*]] = p4hir.cmp(gt, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[GT]])
+    %res2_lt = p4hir.cmp(lt, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_lt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res3_lt = p4hir.cmp(lt, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_lt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res4_lt = p4hir.cmp(lt, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_lt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res5_lt = p4hir.cmp(lt, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_lt) : (!p4hir.bool) -> ()
+
+    // LE
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res1_le = p4hir.cmp(le, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_le) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[GE:.*]] = p4hir.cmp(ge, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[GE]])
+    %res2_le = p4hir.cmp(le, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_le) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res3_le = p4hir.cmp(le, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_le) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res4_le = p4hir.cmp(le, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_le) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res5_le = p4hir.cmp(le, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_le) : (!p4hir.bool) -> ()
+
+    // GT
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res1_gt = p4hir.cmp(gt, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_gt) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[LT:.*]] = p4hir.cmp(lt, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[LT]])
+    %res2_gt = p4hir.cmp(gt, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_gt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res3_gt = p4hir.cmp(gt, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_gt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%false)
+    %res4_gt = p4hir.cmp(gt, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_gt) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res5_gt = p4hir.cmp(gt, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_gt) : (!p4hir.bool) -> ()
+
+    // GE
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res1_ge = p4hir.cmp(ge, %arg_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res1_ge) : (!p4hir.bool) -> ()
+
+    // CHECK: %[[LE:.*]] = p4hir.cmp(le, %[[ARG]], %[[c5_i32i]])
+    // CHECK: p4hir.call @blackhole_bool (%[[LE]])
+    %res2_ge = p4hir.cmp(ge, %c5_i32i, %arg_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res2_ge) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res3_ge = p4hir.cmp(ge, %c15_i32i, %c10_i32i) : !i32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res3_ge) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res4_ge = p4hir.cmp(ge, %c0_b32i, %c0_b32i) : !b32i, !p4hir.bool
+    p4hir.call @blackhole_bool(%res4_ge) : (!p4hir.bool) -> ()
+
+    // CHECK: p4hir.call @blackhole_bool (%true)
+    %res5_ge = p4hir.cmp(ge, %c45506_int, %c255_int) : !int, !p4hir.bool
+    p4hir.call @blackhole_bool(%res5_ge) : (!p4hir.bool) -> ()
+
+    p4hir.return
+  }
+}

--- a/test/Transforms/Folds/slice.mlir
+++ b/test/Transforms/Folds/slice.mlir
@@ -1,0 +1,53 @@
+// RUN: p4mlir-opt --canonicalize %s | FileCheck %s
+
+!b5i = !p4hir.bit<5>
+!b9i = !p4hir.bit<9>
+!b11i = !p4hir.bit<11>
+!i11i = !p4hir.int<11>
+!int = !p4hir.infint
+
+#int1396_int = #p4hir.int<1396> : !int
+#int-652_i11i = #p4hir.int<-652> : !i11i
+#int-652_b11i = #p4hir.int<1396> : !b11i
+
+// CHECK-DAG: #[[ATTR_21:.+]] = #p4hir.int<21> : !b5i
+// CHECK-DAG: #[[ATTR_372:.+]] =  #p4hir.int<372> : !b9i
+
+// CHECK-LABEL: module
+module {
+  p4hir.func @blackhole_b5i(!b5i)
+  p4hir.func @blackhole_b9i(!b9i)
+
+  // CHECK: p4hir.func @test
+  p4hir.func @test() {
+    // CHECK-DAG: %[[CONST_21:.*]] = p4hir.const #[[ATTR_21]]
+    // CHECK-DAG: %[[CONST_372:.*]] = p4hir.const #[[ATTR_372]]
+
+    %c_infint = p4hir.const #int1396_int
+    %c_int = p4hir.const #int-652_i11i
+    %c_bit = p4hir.const #int-652_b11i
+
+    // CHECK: p4hir.call @blackhole_b5i (%[[CONST_21]]) : (!b5i) -> ()
+    // CHECK: p4hir.call @blackhole_b9i (%[[CONST_372]]) : (!b9i) -> ()
+    %p1_infint = p4hir.slice %c_infint[10 : 6] : !int -> !b5i
+    p4hir.call @blackhole_b5i(%p1_infint) : (!b5i) -> ()
+    %p2_infint = p4hir.slice %c_infint[8 : 0] : !int -> !b9i
+    p4hir.call @blackhole_b9i(%p2_infint) : (!b9i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b5i (%[[CONST_21]]) : (!b5i) -> ()
+    // CHECK: p4hir.call @blackhole_b9i (%[[CONST_372]]) : (!b9i) -> ()
+    %p1_int = p4hir.slice %c_int[10 : 6] : !i11i -> !b5i
+    p4hir.call @blackhole_b5i(%p1_int) : (!b5i) -> ()
+    %p2_int = p4hir.slice %c_int[8 : 0] : !i11i -> !b9i
+    p4hir.call @blackhole_b9i(%p2_int) : (!b9i) -> ()
+
+    // CHECK: p4hir.call @blackhole_b5i (%[[CONST_21]]) : (!b5i) -> ()
+    // CHECK: p4hir.call @blackhole_b9i (%[[CONST_372]]) : (!b9i) -> ()
+    %p1_bit = p4hir.slice %c_bit[10 : 6] : !b11i -> !b5i
+    p4hir.call @blackhole_b5i(%p1_bit) : (!b5i) -> ()
+    %p2_bit = p4hir.slice %c_bit[8 : 0] : !b11i -> !b9i
+    p4hir.call @blackhole_b9i(%p2_bit) : (!b9i) -> ()
+
+    p4hir.return
+  }
+}


### PR DESCRIPTION
This PR adds folding and canonicalization for BinOp, CmpOp and SliceOp. It also introduces useful helpers and simplifies existing code.

Some of the patterns were inspired by the `arith` base dialect. It also includes the BinOp verifier from #164.

There are potentially more patterns to be added, but this should be a good start.