### PR TITLE
Add missing P4HIRToCoreLib conversion patterns and clean up code

### DIFF
--- a/lib/Conversion/P4HIRToCoreLib.cpp
+++ b/lib/Conversion/P4HIRToCoreLib.cpp
@@ -189,11 +189,7 @@ void LowerToP4CoreLib::runOnOperation() {
                  CallMethodOpConversionPattern, OverloadSetOpConversionPattern>(converter,
                                                                                 &context);
 
-    // Translate call operands and results via type converter
-    populateOpInterfaceTypeConversionPattern<mlir::CallOpInterface>(patterns, converter);
-    // Translate function-like ops signatures and types
-    populateOpTypeConversionPattern<P4HIR::FuncOp, P4HIR::ParserOp, P4HIR::ControlOp>(patterns,
-                                                                                      converter);
+    populateTypeConversionPattern(patterns, converter);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) signalPassFailure();
 }

--- a/test/Conversion/P4CoreLib/control-locals.mlir
+++ b/test/Conversion/P4CoreLib/control-locals.mlir
@@ -1,0 +1,47 @@
+// RUN: p4mlir-opt %s --lower-to-p4corelib | FileCheck %s
+
+!b16i = !p4hir.bit<16>
+!b32i = !p4hir.bit<32>
+!b48i = !p4hir.bit<48>
+!error = !p4hir.error<NoError, PacketTooShort, NoMatch, StackOutOfBounds, HeaderTooShort, ParserTimeout, ParserInvalidArgument>
+!packet_out = !p4hir.extern<"packet_out" annotations {corelib}>
+!string = !p4hir.string
+!type_T = !p4hir.type_var<"T">
+!validity_bit = !p4hir.validity.bit
+#in = #p4hir<dir in>
+#out = #p4hir<dir out>
+#undir = #p4hir<dir undir>
+!ethernet_t = !p4hir.header<"ethernet_t", dst_addr: !b48i, src_addr: !b48i, ether_type: !b16i, __valid: !validity_bit>
+!headers_t = !p4hir.struct<"headers_t", u0_ethernet: !ethernet_t>
+module {
+  p4hir.extern @packet_in annotations {corelib} {
+    p4hir.overload_set @extract {
+      p4hir.func @extract_0<!type_T>(!p4hir.ref<!type_T> {p4hir.dir = #out, p4hir.param_name = "hdr"})
+      p4hir.func @extract_1<!type_T>(!p4hir.ref<!type_T> {p4hir.dir = #out, p4hir.param_name = "variableSizeHeader"}, !b32i {p4hir.dir = #in, p4hir.param_name = "variableFieldSizeInBits"})
+    }
+    p4hir.func @lookahead<!type_T>() -> !type_T
+    p4hir.func @advance(!b32i {p4hir.dir = #in, p4hir.param_name = "sizeInBits"})
+    p4hir.func @length() -> !b32i
+  }
+  p4hir.extern @packet_out annotations {corelib} {
+    p4hir.func @emit<!type_T>(!type_T {p4hir.dir = #in, p4hir.param_name = "hdr"})
+  }
+  p4hir.func @verify(!p4hir.bool {p4hir.dir = #in, p4hir.param_name = "check"}, !error {p4hir.dir = #in, p4hir.param_name = "toSignal"}) annotations {corelib}
+  p4hir.func action @NoAction() annotations {noWarn = "unused"} {
+    p4hir.return
+  }
+  p4hir.overload_set @static_assert {
+    p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"}, !string {p4hir.dir = #undir, p4hir.param_name = "message"}) -> !p4hir.bool annotations {corelib}
+    p4hir.func @static_assert_1(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"}) -> !p4hir.bool annotations {corelib}
+  }
+  // CHECK-LABEL: p4hir.control
+  p4hir.control @deparser(%arg0: !packet_out {p4hir.dir = #undir, p4hir.param_name = "packet"}, %arg1: !headers_t {p4hir.dir = #in, p4hir.param_name = "hdr"})() {
+    // CHECK: p4hir.control_local @__local_deparser_packet_0 = %arg0 : !p4corelib.packet_out
+    p4hir.control_local @__local_deparser_packet_0 = %arg0 : !packet_out
+    p4hir.control_local @__local_deparser_hdr_0 = %arg1 : !headers_t
+    p4hir.control_apply {
+      %u0_ethernet = p4hir.struct_extract %arg1["u0_ethernet"] : !headers_t
+      p4hir.call_method @packet_out::@emit<[!ethernet_t]> of %arg0 : !packet_out (%u0_ethernet) : (!ethernet_t) -> ()
+    }
+  }
+}


### PR DESCRIPTION
When we have a `p4hir.control_local` that references a `packet_out` type, the `lower-to-p4corelib` pass will fail translation due to not having a pattern for updating the types in `p4hir.control_local` (see the added `control_locals.mlir` file). This may happen with any other operation that uses types that need conversion.

This PR fixes the issue by adding `populateTypeConversionPattern` in `P4HIRToCoreLib.cpp`.

I also suggest that we remove `populateP4HIRFunctionOpTypeConversionPattern` and `populateP4HIRAnyCallOpTypeConversionPattern` because they're reduntant and can be replaced with a single `populateTypeConversionPattern`. This is simpler and more efficient.

If for some reason the removal of `populateP4HIRFunctionOpTypeConversionPattern` and `populateP4HIRAnyCallOpTypeConversionPattern` is unwanted, I can update the PR to only include the fix.