### PR TITLE
Add p4mlir-to-json tool

### DIFF
--- a/include/p4mlir/Common/Registration.h
+++ b/include/p4mlir/Common/Registration.h
@@ -1,0 +1,34 @@
+#ifndef P4MLIR_COMMON_REGISTRATION_H
+#define P4MLIR_COMMON_REGISTRATION_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "p4mlir/Conversion/P4HIRToBMv2IR/Passes.h"
+#include "p4mlir/Conversion/P4HIRToCoreLib/Passes.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.h"
+#include "p4mlir/Dialect/BMv2IR/Pipelines/Passes.h"
+#include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Dialect.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
+#include "p4mlir/Dialect/P4HIR/Pipelines/Passes.h"
+#include "p4mlir/Targets/BMv2/Target.h"
+#include "p4mlir/Transforms/Passes.h"
+
+namespace P4::P4MLIR {
+
+inline void registerAllDialects(mlir::DialectRegistry &registry) {
+    registry.insert<P4::P4MLIR::P4HIR::P4HIRDialect, P4::P4MLIR::P4CoreLib::P4CoreLibDialect,
+                    P4::P4MLIR::BMv2IR::BMv2IRDialect, mlir::func::FuncDialect>();
+}
+
+inline void registerAllPassesAndPipelines() {
+    P4::P4MLIR::registerPasses();
+    P4::P4MLIR::registerP4HIRToCoreLibPasses();
+    P4::P4MLIR::registerP4HIRToBMv2IRPasses();
+    P4::P4MLIR::registerCommonFrontEndPipeline();
+    P4::P4MLIR::registerBMv2Pipeline();
+}
+
+inline void registerAllTranslations() { P4::P4MLIR::registerToBMv2JSONTranslation(); }
+}  // namespace P4::P4MLIR
+
+#endif  // P4MLIR_COMMON_REGISTRATION_H

--- a/include/p4mlir/Targets/BMv2/Target.h
+++ b/include/p4mlir/Targets/BMv2/Target.h
@@ -1,7 +1,10 @@
 #include "llvm/Support/JSON.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
 
 namespace P4::P4MLIR {
+
+mlir::LogicalResult bmv2irToJson(mlir::ModuleOp moduleOp, mlir::raw_ostream &output);
 
 // Serializes a BMv2IR module to its final JSON representation
 mlir::FailureOr<llvm::json::Value> bmv2irToJson(mlir::ModuleOp moduleOp);

--- a/lib/Targets/BMv2/Target.cpp
+++ b/lib/Targets/BMv2/Target.cpp
@@ -1,7 +1,9 @@
 #include "p4mlir/Targets/BMv2/Target.h"
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
+#include "p4mlir/Common/Registration.h"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.h"
 
 using namespace mlir;
@@ -18,11 +20,16 @@ void P4::P4MLIR::registerToBMv2JSONTranslation() {
         [](Operation *op, raw_ostream &output) {
             auto moduleOp = dyn_cast<ModuleOp>(op);
             if (!moduleOp) return failure();
-            auto maybeJsonModule = bmv2irToJson(moduleOp);
-            if (failed(maybeJsonModule)) return failure();
-
-            output << *maybeJsonModule;
+            if (failed(bmv2irToJson(moduleOp, output))) return failure();
             return success();
         },
-        [](DialectRegistry &registry) { registry.insert<BMv2IR::BMv2IRDialect>(); });
+        [](DialectRegistry &registry) { P4::P4MLIR::registerAllDialects(registry); });
+}
+
+LogicalResult P4::P4MLIR::bmv2irToJson(ModuleOp moduleOp, raw_ostream &output) {
+    auto maybeJsonModule = bmv2irToJson(moduleOp);
+    if (failed(maybeJsonModule)) return failure();
+
+    output << *maybeJsonModule;
+    return success();
 }

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -55,6 +55,7 @@ tool_dirs = [config.p4mlir_tools_dir, config.llvm_tools_dir]
 tools = [
     "mlir-opt",
     "p4mlir-opt",
+    "p4mlir-to-json",
     "p4mlir-translate"
 ]
 

--- a/test/p4mlir-to-json.mlir
+++ b/test/p4mlir-to-json.mlir
@@ -1,0 +1,3 @@
+// RUN: p4mlir-to-json --help | FileCheck %s
+// CHECK:       Translations to perform
+// CHECK-NEXT:  --p4hir-to-bmv2-json

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(p4mlir-translate)
 add_subdirectory(p4mlir-opt)
+add_subdirectory(p4mlir-to-json)

--- a/tools/p4mlir-opt/p4mlir-opt.cpp
+++ b/tools/p4mlir-opt/p4mlir-opt.cpp
@@ -1,30 +1,18 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
-#include "p4mlir/Conversion/P4HIRToBMv2IR/Passes.h"
-#include "p4mlir/Conversion/P4HIRToCoreLib/Passes.h"
-#include "p4mlir/Dialect/BMv2IR/Pipelines/Passes.h"
-#include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Dialect.h"
-#include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
-#include "p4mlir/Dialect/P4HIR/Pipelines/Passes.h"
-#include "p4mlir/Transforms/Passes.h"
+#include "p4mlir/Common/Registration.h"
 
 int main(int argc, char **argv) {
     mlir::registerTransformsPasses();
 
-    P4::P4MLIR::registerPasses();
-    P4::P4MLIR::registerP4HIRToCoreLibPasses();
-    P4::P4MLIR::registerP4HIRToBMv2IRPasses();
-    P4::P4MLIR::registerCommonFrontEndPipeline();
-    P4::P4MLIR::registerBMv2Pipeline();
+    P4::P4MLIR::registerAllPassesAndPipelines();
 
     mlir::DialectRegistry registry;
-    registry.insert<P4::P4MLIR::P4HIR::P4HIRDialect, P4::P4MLIR::P4CoreLib::P4CoreLibDialect,
-                    mlir::func::FuncDialect>();
+    P4::P4MLIR::registerAllDialects(registry);
 
     return mlir::asMainReturnCode(
         mlir::MlirOptMain(argc, argv, "P4MLIR optimizer driver\n", registry));

--- a/tools/p4mlir-to-json/CMakeLists.txt
+++ b/tools/p4mlir-to-json/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(LIBS
+  MLIRTranslateLib
+  P4MLIR_P4HIR
+  P4MLIR_P4CoreLib
+  P4MLIR_BMv2IR
+  P4MLIRConversion
+  P4MLIRTransforms
+  P4MLIRConversion
+  P4HIRToBMv2IR
+  P4Pipelines
+  BMv2Pipelines
+  P4MLIR_TargetBMv2
+
+
+  MLIRFuncDialect
+  MLIROptLib
+)
+
+add_llvm_executable(p4mlir-to-json
+    p4mlir-to-json.cpp
+)
+
+llvm_update_compile_flags(p4mlir-to-json)
+mlir_target_link_libraries(p4mlir-to-json PRIVATE ${LIBS})
+
+mlir_check_all_link_libraries(p4mlir-to-json)

--- a/tools/p4mlir-to-json/p4mlir-to-json.cpp
+++ b/tools/p4mlir-to-json/p4mlir-to-json.cpp
@@ -1,0 +1,10 @@
+#include "mlir/Support/LLVM.h"
+#include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
+#include "p4mlir/Common/Registration.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+    P4::P4MLIR::registerAllTranslations();
+    return failed(mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));
+}


### PR DESCRIPTION
This PR adds the `p4mlir-to-json` tool, which is used to lower P4 MLIR dialects to JSON targeting P4 backends. Backends are expected to register translations, which are automatically picked up by `mlirTranslateMain`.
The PR also includes a small refactoring for `p4-opt`, which now uses common registration functions for P4 dialects, passes and pipelines.