### PR TITLE
Fix translator crash on empty loop updates

### DIFF
--- a/lib/P4C/translate.cpp
+++ b/lib/P4C/translate.cpp
@@ -3585,7 +3585,8 @@ bool P4HIRConverter::preorder(const P4::IR::ForStatement *fstmt) {
                 ValueScope scope(*p4Values);
 
                 visit(fstmt->updates);
-                P4HIR::buildTerminatedBody(b, getEndLoc(builder, fstmt->updates.back()));
+                const auto *locNode = fstmt->updates.empty() ? fstmt : fstmt->updates.back();
+                P4HIR::buildTerminatedBody(b, getEndLoc(builder, locNode));
             });
     };
 

--- a/test/Translate/Ops/for.p4
+++ b/test/Translate/Ops/for.p4
@@ -40,6 +40,13 @@ bit<32> loop() {
     return sum;
 }
 
+// CHECK-LABEL: p4hir.func @empty_statements()
+void empty_statements() {
+    // Check that we don't crash when init or updates is empty.
+    for (bit<32> i = 0; i < 10;) {}
+    for (; false;) {}
+}
+
 // CHECK-LABEL: p4hir.func action @multiple_statements
 // CHECK:        p4hir.scope {
 // CHECK:          %[[CONST_0_I:.*]] = p4hir.const #int0_b8i


### PR DESCRIPTION
The `updates` part of a loop may be empty, in which case we get a crash in translator.