### PR TITLE
Improved support for array-like types.

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1905,8 +1905,7 @@ let description = [{
   The `p4hir.foreach` operation executes a statement for each element in a collection.
 }];
 
-  // TODO: Should support either ArrayTypes or SetTypes
-  let arguments = (ins SetType:$collection,
+  let arguments = (ins AnyCollectionType:$collection,
                        OptionalAttr<DictionaryAttr>:$annotations);
 
   let regions = (region AnyRegion:$bodyRegion);

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -945,6 +945,7 @@ def LoadableP4Type : AnyTypeOf<[BitsType, VarBitsType, BooleanType, InfIntType,
                                 EnumType, SerEnumType, ErrorType,
                                 ValidBitType, AliasType, ArrayType]> {}
 def AnyEnumType : AnyTypeOf<[EnumType, SerEnumType]>;
+def AnyCollectionType : AnyTypeOf<[HeaderStackType, SetType, ArrayType]> {}
 def SwitchCondType : AnyTypeOf<[AnyIntP4Type, AnyEnumType, ErrorType]>;
 def StructLikeType : AnyTypeOf<[StructType, HeaderType, HeaderUnionType, HeaderStackType]>;
 def P4ObjectType : AnyTypeOf<[ParserType, ControlType, ExternType, PackageType]>;

--- a/lib/Dialect/P4HIR/P4HIR_Types.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Types.cpp
@@ -437,6 +437,8 @@ LogicalResult HeaderType::verify(function_ref<InFlightDiagnostic()> emitError, S
             auto fieldType = elt.type;
             if (auto aliasType = mlir::dyn_cast<P4HIR::AliasType>(fieldType))
                 fieldType = aliasType.getCanonicalType();
+            while (auto arrayType = mlir::dyn_cast<P4HIR::ArrayType>(fieldType))
+                fieldType = arrayType.getElementType();
 
             // varbit and validity bit are allowed at the top (header) level only
             if (isHeader && mlir::isa<P4HIR::VarBitsType, P4HIR::ValidBitType>(fieldType)) {

--- a/test/Translate/Ops/for.p4
+++ b/test/Translate/Ops/for.p4
@@ -108,3 +108,23 @@ bit<32> for_in() {
     }
     return sum;
 }
+
+// CHECK-LABEL: p4hir.func @for_in_array
+// CHECK-SAME:    (%[[ARRAY_ARG:.*]]: !arr_16xb32i {{.*}}) -> !b32i
+// CHECK:       %[[CONST_0:.*]] = p4hir.const #int0_b32i
+// CHECK:       %[[CAST_0:.*]] = p4hir.cast(%[[CONST_0]] : !b32i) : !b32i
+// CHECK:       %[[SUM:.*]] = p4hir.variable ["sum", init] : <!b32i>
+// CHECK:       p4hir.assign %[[CAST_0]], %[[SUM]] : <!b32i>
+// CHECK:       p4hir.foreach %[[ARG:.*]] : !b32i in %[[ARRAY_ARG]] : !arr_16xb32i {
+// CHECK:         %[[SUM_VAL:.*]] = p4hir.read %sum : <!b32i>
+// CHECK:         %[[ADD:.*]] = p4hir.binop(add, %[[SUM_VAL]], %[[ARG]]) : !b32i
+// CHECK:         p4hir.assign %[[ADD]], %[[SUM]] : <!b32i>
+// CHECK:         p4hir.yield
+// CHECK:       }
+bit<32> for_in_array(bit<32>[16] array) {
+    bit<32> sum = 0;
+    for (bit<32> x in array) {
+        sum = sum + x;
+    }
+    return sum;
+}


### PR DESCRIPTION
This PR adds missing support for array-like types in various places:
 - Function arguments
 - Header definitions
 - For each statements (both header stacks and pure array types).
 - Indexing expressions (support was only present for header stacks specifically in some places).