### PR TITLE
Support constructor argument access in control actions

### DIFF
--- a/lib/P4C/translate.cpp
+++ b/lib/P4C/translate.cpp
@@ -2248,6 +2248,16 @@ bool P4HIRConverter::preorder(const P4::IR::Method *m) {
 
 bool P4HIRConverter::preorder(const P4::IR::P4Action *act) {
     ConversionTracer trace("Converting ", act);
+
+    const auto *control = findContext<P4::IR::P4Control>();
+    llvm::SmallVector<mlir::TypedAttr, 2> ctorParamAttrs;
+    if (control) {
+        for (const auto *param : control->getConstructorParameters()->parameters) {
+            auto attr = getValue(param).getDefiningOp<P4HIR::ConstOp>().getValue();
+            ctorParamAttrs.push_back(attr);
+        }
+    }
+
     ValueTable actionValues, *savedValues = p4Values;
     p4Values = &actionValues;
     ValueScope scope(actionValues);
@@ -2276,6 +2286,18 @@ bool P4HIRConverter::preorder(const P4::IR::P4Action *act) {
     {
         mlir::OpBuilder::InsertionGuard guard(builder);
         builder.setInsertionPointToStart(&body.front());
+
+        if (control) {
+            // Actions could refer to control's constructor arguments. Materialize them as
+            // constants.
+            for (auto [param, attr] :
+                 llvm::zip_equal(control->getConstructorParameters()->parameters, ctorParamAttrs)) {
+                llvm::StringRef paramName = param->name.string_view();
+                auto val = builder.create<P4HIR::ConstOp>(getLoc(builder, param), attr, paramName);
+                setValue(param, val);
+            }
+        }
+
         visit(act->body);
 
         // Check if body's last block is not terminated.

--- a/test/Translate/Control/inner_inst.p4
+++ b/test/Translate/Control/inner_inst.p4
@@ -16,8 +16,13 @@ control Pipe(bit<10> arg1, in int<16> arg2, out int<16> arg3, inout int<16> arg4
     // CHECK: p4hir.instantiate @InnerPipe (%true : !p4hir.bool) as @inner1
     // CHECK: p4hir.instantiate @InnerPipe (%false : !p4hir.bool) as @inner2
     
+    // CHECK-LABEL: action @bar
     action bar() {
-        int<16> x1;
+        // CHECK-DAG: %[[CTR_ARG1:.*]] = p4hir.const ["ctr_arg1"] #Pipe_ctr_arg1
+        // CHECK-DAG: %{{.*}} = p4hir.const ["hdr_arg"] #Pipe_hdr_arg
+        // CHECK-DAG: %[[X:.*]] = p4hir.variable ["x1", init] : <!i16i>
+        // CHECK-DAG: p4hir.assign %[[CTR_ARG1]], %[[X]] : <!i16i>
+        int<16> x1 = ctr_arg1;
         return;
     }
 


### PR DESCRIPTION
Currently control constructor arguments cannot be accessed inside control actions, it results in the translator crashing.
This PR makes all constructor constants available in actions, as it is expected.

Since constructor arguments are referred to using the `ctor_param` attribute and a name, I believe we don't need to export them as control locals and can use the same IR as when they're accessed outside actions.

The constants are created eagerly in all actions, so unused arguments will be cleaned up only when the canonicalizer is ran.