### PR TITLE
Add initial implementation for BMv2 headers and parsers

### DIFF
--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.h
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.h
@@ -9,9 +9,10 @@
 
 #include "llvm/ADT/APSInt.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.h"
 
+// clang-format off
 #define GET_ATTRDEF_CLASSES
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_EnumAttrs.h.inc"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.h.inc"
 
 #endif  // P4MLIR_DIALECT_BMv2IR_BMv2IR_ATTRS_H

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.td
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.td
@@ -2,6 +2,8 @@
 #define P4MLIR_DIALECT_BMv2IR_BMv2IR_ATTRS_TD
 
 include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/EnumAttr.td"
 
 include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.td"
 
@@ -9,5 +11,29 @@ class BMv2IR_Attr<string name, string attrMnemonic, list<Trait> traits = []>
     : AttrDef<BMv2IR_Dialect, name, traits> {
   let mnemonic = attrMnemonic;
 }
+
+def BMv2IR_ExtractKind : IntEnum<"ExtractKind",
+    "BMv2 extract operation kind",
+    [
+      I32EnumAttrCase<"Regular", 0, "regular">,
+      I32EnumAttrCase<"Stack", 1, "stack">,
+      I32EnumAttrCase<"UnionStack", 2, "union_stack">
+    ], 32> {
+  let cppNamespace = "P4::P4MLIR::BMv2IR";
+}
+
+def BMv2IR_ExtractKindAttr : EnumAttr<BMv2IR_Dialect, BMv2IR_ExtractKind, "extract_kind">;
+
+def BMv2IR_TransitionKind : IntEnum<"TransitionKind",
+    "BMv2 extract operation kind",
+    [
+      I32EnumAttrCase<"Default", 0, "default">,
+      I32EnumAttrCase<"Hexstr", 1, "hexstr">,
+      I32EnumAttrCase<"Parse_vset", 2, "parse_vset">
+    ], 32> {
+  let cppNamespace = "P4::P4MLIR::BMv2IR";
+}
+
+def BMv2IR_TransitionKindAttr : EnumAttr<BMv2IR_Dialect, BMv2IR_TransitionKind, "transition_kind">;
 
 #endif // P4MLIR_DIALECT_BMv2IR_BMv2IR_ATTRS_TD

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.td
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.td
@@ -18,6 +18,9 @@ def BMv2IR_Dialect : Dialect {
     }];
     let cppNamespace = "::P4::P4MLIR::BMv2IR";
 
+    let useDefaultTypePrinterParser = 1;
+    let useDefaultAttributePrinterParser = 1;
+
     let extraClassDeclaration = [{
         void registerAttributes();
         void registerTypes();

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.h
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.h
@@ -1,0 +1,7 @@
+#ifndef P4MLIR_DIALECT_BMv2IR_BMv2IR_OPINTERFACES_H
+#define P4MLIR_DIALECT_BMv2IR_BMv2IR_OPINTERFACES_H
+
+#include "mlir/IR/OpDefinition.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.h.inc"
+
+#endif  // P4MLIR_DIALECT_BMv2IR_BMv2IR_OPINTERFACES_H

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.td
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.td
@@ -1,0 +1,27 @@
+#ifndef BMv2IR_OP_INTERFACES_TD
+#define BMv2IR_OP_INTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/Interfaces.td"
+
+def AllowedTransitionKey : OpInterface<"AllowedTransitionKey"> {
+  let description = [{
+    Common interfaces for operations that could be used as transition keys
+  }];
+  let methods = [];
+
+
+  let cppNamespace = "::P4::P4MLIR::BMv2IR";
+}
+
+def AllowedParserOp : OpInterface<"AllowedParserOp"> {
+  let description = [{
+    Common interfaces for operations that could be used as parser ops
+  }];
+  let methods = [];
+
+
+  let cppNamespace = "::P4::P4MLIR::BMv2IR";
+}
+
+#endif

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Ops.h
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Ops.h
@@ -9,8 +9,10 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/SymbolTable.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.h"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.h"
-
 #define GET_OP_CLASSES
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Ops.h.inc"
 

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Ops.td
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Ops.td
@@ -2,9 +2,13 @@
 #define P4MLIR_DIALECT_BMv2IR_BMv2IR_OPS_TD
 
 include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
+
 
 include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.td"
 include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.td"
+include "p4mlir/Dialect/BMv2IR/BMv2IR_Attrs.td"
+include "p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Base BMv2IR operation definition.
@@ -12,5 +16,182 @@ include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.td"
 
 class BMv2IR_Op<string mnemonic, list<Trait> traits = []> :
         Op<BMv2IR_Dialect, mnemonic, traits>;
+
+def BMv2IR_ParserOp : BMv2IR_Op<"parser", [
+    Symbol, SymbolTable,
+    SingleBlock, NoTerminator
+  ]> {
+  let summary = "P4 parser definition";
+  let description = [{
+    Represents a P4 parser with an initial state and a set of parse states.
+    
+    Example:
+    ```mlir
+    bmv2.parser @my_parser init_state @start {
+      // parse states here
+    }
+    ```
+  }];
+  
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    SymbolRefAttr:$init_state
+  );
+  
+  let regions = (region SizedRegion<1>:$body);
+  
+  let assemblyFormat = [{
+    $sym_name `init_state` $init_state $body attr-dict
+  }];
+}
+
+def BMv2IR_ParserStateOp : BMv2IR_Op<"state",
+   [HasParent<"ParserOp">,
+    Symbol, NoTerminator]> {
+  let arguments = (ins
+    SymbolNameAttr:$sym_name
+  );
+  let description = [{ 
+    Represents a BMv2 parse state.
+    The op has 3 regions, which match the JSON format for parse states:
+    - parser_ops contains the operations performed by the state to parse the header
+    - transition_keys contains the keys from select transitions
+    - transitions contains the actual transitions
+  }];
+  
+  let regions = (region 
+      SizedRegion<1>:$parser_ops,
+      SizedRegion<1>:$transitions,
+      SizedRegion<1>:$transition_keys);
+  
+  let assemblyFormat = [{
+    $sym_name
+    `\n``transition_key` $transition_keys
+    `\n``transitions` $transitions
+    `\n``parser_ops` $parser_ops attr-dict
+  }];
+
+  let hasVerifier = 1;
+}
+
+def BMv2IR_TransitionOp : BMv2IR_Op<"transition", [HasParent<"ParserStateOp">]> {
+  let summary = "Parser transition";
+  let description = [{
+    Represents a single transition from a parse state.
+    
+    Types:
+    - default: default transition (no value/mask)
+    - hexstr: value-based transition with hexstring
+    - parse_vset: parse value-set based transition
+    
+    The value and mask are hexstrings in the format described in the BMv2 JSON
+    spec (concatenation of byte-padded fields). For example, if the transition
+    key has a 12-bit field and a 2-bit field, values use 3 bytes (0x0aba03).
+    
+    `next_state` can be null for the last state in the parser.
+    `value` is the hexstr value or vset name (null if default)
+    `mask` is the mask (if needed) for the hexstr
+  }];
+  
+  // TODO: refine value and mask fields
+  let arguments = (ins
+    BMv2IR_TransitionKindAttr:$type,
+    OptionalAttr<SymbolRefAttr>:$next_state,
+    OptionalAttr<AnyAttr>:$value,
+    OptionalAttr<AnyAttr>:$mask
+  );
+  
+  let assemblyFormat = "`type`$type (`value` $value^)? (`mask` $mask^)? (`next_state` $next_state^)? attr-dict";
+}
+
+
+def BMv2_ExtractOp : BMv2IR_Op<"extract", [HasParent<"ParserStateOp">, AllowedParserOp]> {
+  let summary = "Extract header operation";
+  let description = [{
+    Extracts the field of a header instance, header stack, or union stack element.
+    
+    Types:
+    - regular: extraction to a regular header instance
+    - stack: extraction to the end of a header stack
+    - union_stack: extraction to the end of a header union stack
+  }];
+  
+  let arguments = (ins
+    BMv2IR_ExtractKindAttr:$extract_type,
+    StrAttr:$value,
+    OptionalAttr<StrAttr>:$union_member
+  );
+  
+  let assemblyFormat = [{
+    $extract_type $value (`union_member` $union_member^)? attr-dict
+  }];
+}
+
+//===-------------------------------------------------------------------------------------------===//
+// BMv2 type-value fields
+// see https://github.com/p4lang/behavioral-model/blob/main/docs/JSON_format.md#the-type-value-object
+//===-------------------------------------------------------------------------------------------===//
+
+def BMv2IR_FieldOp : BMv2IR_Op<"field", [AllowedTransitionKey]> {
+  let summary = "BMv2 header field access";
+  let description = [{
+    Represents access to a field within a header instance.
+    Contains a 2-tuple: (header_instance_name, field_member_name)
+  }];
+  
+  let arguments = (ins
+    StrAttr:$headerInstance,
+    StrAttr:$fieldMember
+  );
+  
+  let assemblyFormat = "`<` $headerInstance `,` $fieldMember `>` attr-dict";
+}
+
+def BMv2_StackFieldOp : BMv2IR_Op<"stack_field", [AllowedTransitionKey]> {
+  let summary = "BMv2 header stack field access";
+  let description = [{
+    Represents access to a field in the last valid header instance in a stack.
+    Contains a 2-tuple: (header_stack_name, field_member_name)
+  }];
+  
+  let arguments = (ins
+    StrAttr:$headerStack,
+    StrAttr:$fieldMember
+  );
+  
+  let assemblyFormat = "`<` $headerStack `,` $fieldMember `>` attr-dict";
+}
+
+
+def BMv2IR_LookaheadOp : BMv2IR_Op<"lookahead", [AllowedTransitionKey]> {
+  let summary = "BMv2 parser lookahead";
+  let description = [{
+    Represents a lookahead operation in a parser.
+    Contains a 2-tuple: (bit_offset, bitwidth)
+  }];
+  
+  let arguments = (ins
+    I32Attr:$bitOffset,
+    I32Attr:$bitwidth
+  );
+  
+  let assemblyFormat = "`<` $bitOffset `,` $bitwidth `>` attr-dict";
+}
+
+def BMv2_UnionStackFieldOp : BMv2IR_Op<"union_stack_field", [AllowedTransitionKey]> {
+  let summary = "BMv2 header union stack field access";
+  let description = [{
+    Represents access to a field in the last valid union instance in a stack.
+    Contains a 3-tuple: (header_union_stack_name, union_member_name, field_member_name)
+  }];
+  
+  let arguments = (ins
+    StrAttr:$headerUnionStack,
+    StrAttr:$unionMember,
+    StrAttr:$fieldMember
+  );
+  
+  let assemblyFormat = "`<` $headerUnionStack `,` $unionMember `,` $fieldMember `>` attr-dict";
+}
 
 #endif // P4MLIR_DIALECT_BMv2IR_BMv2IR_OPS_TD

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Types.h
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Types.h
@@ -3,9 +3,34 @@
 
 // We explicitly do not use push / pop for diagnostic in
 // order to propagate pragma further on
+#include "llvm/ADT/APFloat.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #include "mlir/IR/BuiltinTypes.h"
+
+namespace P4::P4MLIR::BMv2IR {
+
+// Struct that models a header field info.
+struct FieldInfo {
+    mlir::StringAttr name;
+    mlir::Type type;
+
+    FieldInfo(mlir::StringAttr name, mlir::Type type) : name(name), type(type) {}
+
+    bool operator==(const FieldInfo &other) const {
+        return name == other.name && type == other.type;
+    }
+
+    friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const FieldInfo &f) {
+        return os << f.name.data() << ":" << f.type;
+    }
+
+    friend llvm::hash_code hash_value(P4::P4MLIR::BMv2IR::FieldInfo f);
+};
+
+}  // namespace P4::P4MLIR::BMv2IR
 
 #define GET_TYPEDEF_CLASSES
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.h.inc"

--- a/include/p4mlir/Dialect/BMv2IR/BMv2IR_Types.td
+++ b/include/p4mlir/Dialect/BMv2IR/BMv2IR_Types.td
@@ -15,4 +15,47 @@ class BMv2IR_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
+// P4HeaderType represents a complete header type definition
+def BMv2_HeaderType : BMv2IR_Type<"Header", "header"> {
+  let summary = "BMv2 header type";
+  let description = [{
+    Represents a P4 header according to the
+    [BMv2 JSON spec](https://github.com/p4lang/behavioral-model/blob/main/docs/JSON_format.md#header_types)
+    
+    The type encodes:
+    - A unique name for the header type
+    - An array of fields (name, bitwidth, optional signed flag)
+    - Optional maximum length for variable-length headers
+    
+    Variable-length fields are represented with bitwidth = -1.
+    At most one field can be variable-length.
+  }];
+  
+  let parameters = (ins
+    StringRefParameter<"struct name">:$name,
+    ArrayRefParameter<"BMv2IR::FieldInfo", "struct fields">:$fields,
+    OptionalParameter<"unsigned">:$max_length
+  );
+  
+  let assemblyFormat = [{
+    `<` $name `,` `[` $fields `]`
+    (`,` `max_length` `=` $max_length^)?
+    `>`
+  }];
+  
+  let genVerifyDecl = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [
+     TypeBuilder<(ins "llvm::StringRef":$name, "llvm::ArrayRef<BMv2IR::FieldInfo>":$fields), [{
+      return $_get($_ctxt, name, fields, computeMaxLength(fields));
+    }]>,
+  ];
+  
+  // Add verification for constraints
+  let extraClassDeclaration = [{
+    static unsigned computeMaxLength(llvm::ArrayRef<BMv2IR::FieldInfo>);
+    static bool isAllowedFieldType(mlir::Type ty);
+  }];
+}
+
 #endif // P4MLIR_DIALECT_BMv2IR_BMv2IR_TYPES_TD

--- a/include/p4mlir/Dialect/BMv2IR/CMakeLists.txt
+++ b/include/p4mlir/Dialect/BMv2IR/CMakeLists.txt
@@ -10,5 +10,13 @@ add_dependencies(mlir-headers P4MLIR_BMv2IR_IncGen)
 
 mlir_tablegen(BMv2IR_Attrs.h.inc -gen-attrdef-decls -attrdefs-dialect=bmv2ir)
 mlir_tablegen(BMv2IR_Attrs.cpp.inc -gen-attrdef-defs -attrdefs-dialect=bmv2ir)
+mlir_tablegen(BMv2IR_EnumAttrs.h.inc -gen-enum-decls)
+mlir_tablegen(BMv2IR_EnumAttrs.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(P4MLIR_BMv2IR_AttrIncGen)
 add_dependencies(mlir-headers P4MLIR_BMv2IR_AttrIncGen)
+
+set(LLVM_TARGET_DEFINITIONS BMv2IR_OpInterfaces.td)
+mlir_tablegen(BMv2IR_OpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(BMv2IR_OpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(P4MLIR_BMv2IR_OpsInterfacesIncGen)
+add_dependencies(mlir-headers P4MLIR_BMv2IR_OpsInterfacesIncGen)

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ParserOps.td
@@ -59,6 +59,8 @@ def ParserOp : P4HIR_Op<"parser",
     ParserStateOp getStartState();
 
     void createEntryBlock();
+
+    ParserTransitionOp getStartTransition();
   }];
 }
 

--- a/lib/Conversion/P4HIRToBMv2IR/P4HIRToBMv2IR.cpp
+++ b/lib/Conversion/P4HIRToBMv2IR/P4HIRToBMv2IR.cpp
@@ -1,11 +1,17 @@
-
-#include <optional>
-
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
-#include "p4mlir/Conversion/P4HIRToBMv2IR/Passes.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_Ops.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.h"
 #include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Dialect.h"
+#include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Ops.h"
 
@@ -21,7 +27,242 @@ namespace P4::P4MLIR {
 using namespace P4::P4MLIR;
 
 namespace {
+
+BMv2IR::FieldInfo convertFieldInfo(P4HIR::FieldInfo p4Field) {
+    return BMv2IR::FieldInfo(p4Field.name, p4Field.type);
+}
+
+struct P4HIRToBMv2IRTypeConverter : public mlir::TypeConverter {
+    P4HIRToBMv2IRTypeConverter() {
+        addConversion([&](mlir::Type t) { return t; });
+        addConversion([&](P4HIR::HeaderType headerType) -> Type {
+            SmallVector<BMv2IR::FieldInfo> newFields;
+            for (auto field : headerType.getFields()) {
+                if (!BMv2IR::HeaderType::isAllowedFieldType(field.type)) return nullptr;
+                newFields.push_back(convertFieldInfo(field));
+            }
+            return BMv2IR::HeaderType::get(headerType.getContext(), headerType.getName(),
+                                           newFields);
+        });
+    }
+};
+
+struct ExtractOpConversionPattern : public OpConversionPattern<P4CoreLib::PacketExtractOp> {
+    using OpConversionPattern<P4CoreLib::PacketExtractOp>::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(P4CoreLib::PacketExtractOp op, OpAdaptor operands,
+                                  ConversionPatternRewriter &rewriter) const override {
+        auto context = op.getContext();
+        auto hdr = op.getHdr();
+        auto referredTy = hdr.getType().getObjectType();
+        if (!isa<P4HIR::HeaderType>(referredTy))
+            return op->emitError("Only headers supported as BMv2 extract arguments");
+        auto fieldRefOp = op.getHdr().getDefiningOp<P4HIR::StructFieldRefOp>();
+        if (!fieldRefOp) return op->emitError("Unsupported extract argument");
+        auto fieldName = fieldRefOp.getFieldName();
+        // TODO: support non-regular extracts
+        rewriter.replaceOpWithNewOp<BMv2IR::ExtractOp>(
+            op, BMv2IR::ExtractKindAttr::get(context, BMv2IR::ExtractKind::Regular),
+            rewriter.getStringAttr(fieldName), nullptr);
+        rewriter.eraseOp(fieldRefOp);
+        return success();
+    }
+};
+
+struct ParserStateOpConversionPattern : public OpConversionPattern<P4HIR::ParserStateOp> {
+    using OpConversionPattern<P4HIR::ParserStateOp>::OpConversionPattern;
+    LogicalResult matchAndRewrite(P4HIR::ParserStateOp op, OpAdaptor operands,
+                                  ConversionPatternRewriter &rewriter) const override {
+        auto loc = op.getLoc();
+        auto context = rewriter.getContext();
+
+        SmallVector<Operation *> eraseList;
+
+        auto newState = rewriter.create<BMv2IR::ParserStateOp>(loc, op.getSymNameAttr());
+        auto &transitionBlock = newState.getTransitions().emplaceBlock();
+        auto &keysBlock = newState.getTransitionKeys().emplaceBlock();
+        auto terminator = op.getNextTransition();
+
+        auto conversionOk =
+            TypeSwitch<Operation *, LogicalResult>(terminator)
+                .Case([&](P4HIR::ParserTransitionOp transitionOp) -> LogicalResult {
+                    ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                    rewriter.setInsertionPointToEnd(&transitionBlock);
+                    rewriter.create<BMv2IR::TransitionOp>(
+                        transitionOp.getLoc(),
+                        BMv2IR::TransitionKindAttr::get(context, BMv2IR::TransitionKind::Default),
+                        transitionOp.getStateAttr(), nullptr, nullptr);
+                    eraseList.push_back(transitionOp.getOperation());
+                    return success();
+                })
+                .Case([&](P4HIR::ParserTransitionSelectOp transitionSelectOp) {
+                    for (auto operand : transitionSelectOp.getArgs()) {
+                        auto transitionKey = insertTransitionKey(operand.getDefiningOp(), rewriter,
+                                                                 &keysBlock, eraseList);
+                        if (failed(transitionKey)) return failure();
+                    }
+
+                    for (auto selectOp : transitionSelectOp.selects()) {
+                        auto transition = insertTransition(selectOp, rewriter, &transitionBlock);
+                        if (failed(transition)) return failure();
+                    }
+                    eraseList.push_back(transitionSelectOp);
+                    return success();
+                })
+                .Case([&](P4HIR::ParserAcceptOp acceptOp) {
+                    ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                    rewriter.setInsertionPointToEnd(&transitionBlock);
+                    rewriter.create<BMv2IR::TransitionOp>(
+                        acceptOp.getLoc(),
+                        BMv2IR::TransitionKindAttr::get(context, BMv2IR::TransitionKind::Default),
+                        nullptr, nullptr, nullptr);
+                    eraseList.push_back(acceptOp.getOperation());
+                    return success();
+                })
+                .Case([&](P4HIR::ParserRejectOp rejectOp) {
+                    // TODO: p4c raises a warning "Explicit transition to reject not supported on
+                    // this target"
+                    //  for explicit transitions to reject
+                    ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                    rewriter.setInsertionPointToEnd(&transitionBlock);
+                    rewriter.create<BMv2IR::TransitionOp>(
+                        rejectOp.getLoc(),
+                        BMv2IR::TransitionKindAttr::get(context, BMv2IR::TransitionKind::Default),
+                        nullptr, nullptr, nullptr);
+                    eraseList.push_back(rejectOp.getOperation());
+                    return success();
+                })
+                .Default([](Operation *) { return failure(); });
+
+        if (failed(conversionOk)) return op->emitError("Error while processing state terminator");
+
+        // Move the remaning parser ops to their region, they will be converted by the other
+        // patterns
+        newState.getParserOps().takeBody(op.getBody());
+        for (auto op : eraseList) rewriter.eraseOp(op);
+        rewriter.replaceOp(op, newState);
+
+        return success();
+    }
+
+ private:
+    static LogicalResult insertTransitionKey(Operation *op, ConversionPatternRewriter &rewriter,
+                                             Block *block, SmallVector<Operation *> &eraseList) {
+        auto loc = op->getLoc();
+        if (auto lookAheadOp = dyn_cast<P4CoreLib::PacketLookAheadOp>(op)) {
+            // TODO: not sure how to handle offsets
+            auto offset = rewriter.getI32IntegerAttr(0);
+            // TODO: can PacketLookAheadOp return something other than Bit?
+            auto bitTy = cast<P4HIR::BitsType>(lookAheadOp.getResult().getType());
+            auto width = rewriter.getI32IntegerAttr(bitTy.getWidth());
+            ConversionPatternRewriter::InsertionGuard guard(rewriter);
+            rewriter.setInsertionPointToEnd(block);
+            eraseList.push_back(lookAheadOp);
+            rewriter.create<BMv2IR::LookaheadOp>(loc, offset, width);
+            return success();
+        }
+        return op->emitError("Unhandled transition key");
+    }
+
+    static LogicalResult insertTransition(P4HIR::ParserSelectCaseOp caseOp,
+                                          ConversionPatternRewriter &rewriter, Block *block) {
+        auto context = caseOp.getContext();
+        auto keysets = caseOp.getSelectKeys();
+        auto loc = caseOp.getLoc();
+
+        auto constValOrError = [](Value val) -> llvm::FailureOr<TypedAttr> {
+            auto constOp = val.getDefiningOp<P4HIR::ConstOp>();
+            if (!constOp) return failure();
+
+            return constOp.getValue();
+        };
+
+        for (auto entry : keysets) {
+            return TypeSwitch<Operation *, LogicalResult>(entry.getDefiningOp())
+                .Case([&](P4HIR::SetOp setOp) -> LogicalResult {
+                    auto inputs = setOp.getInput();
+                    for (auto input : inputs) {
+                        auto maybeConstVal = constValOrError(input);
+                        if (failed(maybeConstVal)) return setOp.emitError("Unsupported set entry");
+                        ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                        rewriter.setInsertionPointToEnd(block);
+
+                        rewriter.create<BMv2IR::TransitionOp>(
+                            loc,
+                            BMv2IR::TransitionKindAttr::get(context,
+                                                            BMv2IR::TransitionKind::Hexstr),
+                            caseOp.getStateAttr(), maybeConstVal.value(), nullptr);
+                    }
+                    return success();
+                })
+                .Case([&](P4HIR::ConstOp constOp) {
+                    if (P4HIR::isUniversalSetValue(constOp.getRes())) {
+                        ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                        rewriter.setInsertionPointToEnd(block);
+                        rewriter.create<BMv2IR::TransitionOp>(
+                            loc,
+                            BMv2IR::TransitionKindAttr::get(context,
+                                                            BMv2IR::TransitionKind::Default),
+                            caseOp.getStateAttr(), nullptr, nullptr);
+                        return success();
+                    }
+                    return failure();
+                })
+                .Case([&](P4HIR::MaskOp maskOp) -> LogicalResult {
+                    auto maybeLhsConst = constValOrError(maskOp.getLhs());
+                    auto maybeRhsConst = constValOrError(maskOp.getRhs());
+                    if (failed(maybeLhsConst) || failed(maybeRhsConst))
+                        return maskOp.emitError("Unhandled mask op");
+                    ConversionPatternRewriter::InsertionGuard guard(rewriter);
+                    rewriter.setInsertionPointToEnd(block);
+                    rewriter.create<BMv2IR::TransitionOp>(
+                        maskOp.getLoc(),
+                        BMv2IR::TransitionKindAttr::get(context, BMv2IR::TransitionKind::Hexstr),
+                        caseOp.getStateAttr(), maybeLhsConst.value(), maybeRhsConst.value());
+                    return success();
+                })
+                .Default([&](Operation *) -> LogicalResult {
+                    return caseOp.emitError("Unsupported select case");
+                });
+        }
+        return failure();
+    }
+};
+
+struct ParserOpConversionPattern : public OpConversionPattern<P4HIR::ParserOp> {
+    using OpConversionPattern<P4HIR::ParserOp>::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(P4HIR::ParserOp op, OpAdaptor operands,
+                                  ConversionPatternRewriter &rewriter) const override {
+        auto loc = op.getLoc();
+        auto firstTransition = op.getStartTransition();
+        auto initState = op.getStartState();
+        auto newParser =
+            rewriter.create<BMv2IR::ParserOp>(loc, op.getSymNameAttr(), initState.getSymbolRef());
+        rewriter.eraseOp(firstTransition);
+        auto &region = newParser.getRegion();
+        region.takeBody(op.getRegion());
+        rewriter.replaceOp(op, newParser);
+        return success();
+    }
+};
+
 struct P4HIRToBMv2IRPass : public P4::P4MLIR::impl::P4HIRToBmv2IRBase<P4HIRToBMv2IRPass> {
-    void runOnOperation() override {}
+    void runOnOperation() override {
+        MLIRContext &context = getContext();
+        mlir::ModuleOp module = getOperation();
+        ConversionTarget target(context);
+        RewritePatternSet patterns(&context);
+        P4HIRToBMv2IRTypeConverter converter;
+        patterns.add<ParserOpConversionPattern, ParserStateOpConversionPattern,
+                     ExtractOpConversionPattern>(converter, &context);
+
+        target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+        target.addIllegalOp<P4HIR::ParserOp>();
+        target.addIllegalOp<P4HIR::ParserStateOp>();
+        target.addIllegalOp<P4CoreLib::PacketExtractOp>();
+        if (failed(applyPartialConversion(module, target, std::move(patterns))))
+            signalPassFailure();
+    }
 };
 }  // anonymous namespace

--- a/lib/Dialect/BMv2IR/BMv2IR_Attrs.cpp
+++ b/lib/Dialect/BMv2IR/BMv2IR_Attrs.cpp
@@ -12,6 +12,7 @@
 using namespace mlir;
 using namespace P4::P4MLIR::BMv2IR;
 
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_EnumAttrs.cpp.inc"
 void BMv2IRDialect::registerAttributes() {
     addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/BMv2IR/BMv2IR_Ops.cpp
+++ b/lib/Dialect/BMv2IR/BMv2IR_Ops.cpp
@@ -1,10 +1,38 @@
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Ops.h"
 
+#include "mlir/IR/Builders.h"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.h"
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_OpInterfaces.h"
 
-using namespace P4::P4MLIR;
+using namespace mlir;
+using namespace P4::P4MLIR::BMv2IR;
 
-void BMv2IR::BMv2IRDialect::initialize() {
+LogicalResult ParserStateOp::verify() {
+    // Check that only allowed ops are used as transition keys, transitions and parser ops
+
+    for (auto &block : getTransitionKeys()) {
+        for (auto &op : block) {
+            if (!isa<AllowedTransitionKey>(op)) {
+                return emitError("Op not allowed as transition key");
+            }
+        }
+    }
+
+    for (auto &block : getTransitions()) {
+        for (auto &op : block) {
+            if (!isa<TransitionOp>(op)) return emitError("Op not allowed as transition");
+        }
+    }
+
+    for (auto &block : getParserOps()) {
+        for (auto &op : block) {
+            if (!isa<AllowedParserOp>(op)) return emitError("Op not allowed as parser op");
+        }
+    }
+    return success();
+}
+
+void BMv2IRDialect::initialize() {
     registerTypes();
     registerAttributes();
     addOperations<

--- a/lib/Dialect/BMv2IR/BMv2IR_Types.cpp
+++ b/lib/Dialect/BMv2IR/BMv2IR_Types.cpp
@@ -1,9 +1,97 @@
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LLVM.h"
 #include "p4mlir/Dialect/BMv2IR/BMv2IR_Dialect.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Types.h"
 
 using namespace mlir;
 using namespace P4::P4MLIR;
+
+template <>
+struct mlir::FieldParser<P4::P4MLIR::BMv2IR::FieldInfo> {
+    static FailureOr<P4::P4MLIR::BMv2IR::FieldInfo> parse(AsmParser &parser) {
+        StringRef name;
+
+        if (failed(parser.parseKeyword(&name))) return failure();
+        if (parser.parseColon()) return failure();
+        Type ty;
+        if (parser.parseType(ty)) return failure();
+
+        return BMv2IR::FieldInfo(StringAttr::get(parser.getContext(), name), ty);
+    }
+};
+
+constexpr unsigned bitsInByte = 8;
+static unsigned computeTotalHeaderLenghtInBits(ArrayRef<BMv2IR::FieldInfo> fields) {
+    unsigned total = 0;
+    for (const auto &field : fields) {
+        total += TypeSwitch<Type, unsigned>(field.type)
+                     .Case<P4HIR::BitsType>([](P4HIR::BitsType bitTy) { return bitTy.getWidth(); })
+                     .Case<P4HIR::VarBitsType>(
+                         [](P4HIR::VarBitsType varBitTy) { return varBitTy.getMaxWidth(); })
+                     .Default([](auto) -> unsigned {
+                         llvm_unreachable("Unsupported field in BMv2 header");
+                     });
+    }
+    return total;
+}
+
+bool BMv2IR::HeaderType::isAllowedFieldType(Type ty) {
+    return isa<P4HIR::BitsType, P4HIR::VarBitsType>(ty);
+}
+
+llvm::LogicalResult BMv2IR::HeaderType::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError, ::llvm::StringRef name,
+    ::llvm::ArrayRef<BMv2IR::FieldInfo> fields, unsigned max_length) {
+    if (llvm::any_of(fields, [](BMv2IR::FieldInfo field) {
+            return !BMv2IR::HeaderType::isAllowedFieldType(field.type);
+        })) {
+        emitError() << "Only bits and varbits are allowed in BMv2 headers";
+        return failure();
+    }
+
+    unsigned lenInBits = computeTotalHeaderLenghtInBits(fields);
+    if (lenInBits % bitsInByte != 0) {
+        emitError() << "Expected total size of a header to be byte-sized";
+        return failure();
+    }
+
+    unsigned numVarBits = llvm::count_if(
+        fields, [](BMv2IR::FieldInfo field) { return isa<P4HIR::VarBitsType>(field.type); });
+    if (numVarBits > 1) {
+        emitError() << "Expected at most one field with dynamic size.";
+        return failure();
+    }
+
+    auto computedMaxLength = computeMaxLength(fields);
+    if (max_length != computedMaxLength) {
+        emitError() << "Max length mismatch: expected " << computedMaxLength << " got "
+                    << max_length;
+        return failure();
+    }
+
+    return success();
+}
+
+unsigned BMv2IR::HeaderType::computeMaxLength(ArrayRef<BMv2IR::FieldInfo> fields) {
+    unsigned lenInBits = computeTotalHeaderLenghtInBits(fields);
+    return lenInBits / bitsInByte;
+}
+
+#define GET_TYPEDEF_CLASSES
+#include "p4mlir/Dialect/BMv2IR/BMv2IR_Types.cpp.inc"
+
+llvm::hash_code P4::P4MLIR::BMv2IR::hash_value(P4::P4MLIR::BMv2IR::FieldInfo f) {
+    return llvm::hash_value(f.name.getValue());
+}
 
 void BMv2IR::BMv2IRDialect::registerTypes() {
     addTypes<

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -2087,8 +2087,12 @@ void P4HIR::ParserOp::createEntryBlock() {
     for (auto argType : getArgumentTypes()) first.addArgument(argType, loc);
 }
 
+P4HIR::ParserTransitionOp P4HIR::ParserOp::getStartTransition() {
+    return llvm::cast<ParserTransitionOp>(getBody().back().getTerminator());
+}
+
 P4HIR::ParserStateOp P4HIR::ParserOp::getStartState() {
-    auto transition = llvm::cast<ParserTransitionOp>(getBody().back().getTerminator());
+    auto transition = getStartTransition();
     return lookupParserState(getOperation(), transition.getStateAttr());
 }
 

--- a/test/Conversion/BMv2IR/parser.mlir
+++ b/test/Conversion/BMv2IR/parser.mlir
@@ -1,0 +1,122 @@
+// RUN: p4mlir-opt -p='builtin.module(p4hir-to-bmv2ir)' %s | FileCheck %s
+!b16i = !p4hir.bit<16>
+!b32i = !p4hir.bit<32>
+!b8i = !p4hir.bit<8>
+!validity_bit = !p4hir.validity.bit
+#everything = #p4hir.universal_set : !p4hir.set<!p4hir.dontcare>
+!header_bottom = !p4hir.header<"header_bottom", length: !b8i, data: !p4hir.varbit<256>, __valid: !validity_bit>
+!header_one = !p4hir.header<"header_one", type: !b8i, data: !b8i, __valid: !validity_bit>
+!header_top = !p4hir.header<"header_top", skip: !b8i, __valid: !validity_bit>
+!header_two = !p4hir.header<"header_two", type: !b8i, data: !b16i, __valid: !validity_bit>
+#int1_b8i = #p4hir.int<1> : !b8i
+#int256_b32i = #p4hir.int<256> : !b32i
+#int2_b8i = #p4hir.int<2> : !b8i
+!Headers_t = !p4hir.struct<"Headers_t", top: !header_top, one: !header_one, two: !header_two, bottom: !header_bottom>
+module {
+  p4hir.parser @prs(%arg0: !p4corelib.packet_in {p4hir.dir = #p4hir<dir undir>, p4hir.param_name = "p"}, %arg1: !p4hir.ref<!Headers_t> {p4hir.dir = #p4hir<dir out>, p4hir.param_name = "headers"})() {
+// CHECK:  bmv2ir.parser @prs init_state @prs::@start {
+    p4hir.state @start {
+      %top_field_ref = p4hir.struct_field_ref %arg1["top"] : <!Headers_t>
+      p4corelib.extract_header %top_field_ref : <!header_top> from %arg0 : !p4corelib.packet_in
+      p4hir.transition to @prs::@parse_headers
+    }
+// CHECK:    bmv2ir.state @start
+// CHECK:     transition_key {
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  default next_state @prs::@parse_headers
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:      bmv2ir.extract  regular "top"
+// CHECK:    }
+    p4hir.state @parse_headers {
+      %lookahead = p4corelib.packet_lookahead %arg0 : !p4corelib.packet_in -> !b8i
+      p4hir.transition_select %lookahead : !b8i {
+        p4hir.select_case {
+          %c1_b8i = p4hir.const #int1_b8i
+          %set = p4hir.set (%c1_b8i) : !p4hir.set<!b8i>
+          p4hir.yield %set : !p4hir.set<!b8i>
+        } to @prs::@parse_one
+        p4hir.select_case {
+          %c2_b8i = p4hir.const #int2_b8i
+          %set = p4hir.set (%c2_b8i) : !p4hir.set<!b8i>
+          p4hir.yield %set : !p4hir.set<!b8i>
+        } to @prs::@parse_two
+        p4hir.select_case {
+          %c1_b8i = p4hir.const #int1_b8i
+          %c2_b8i = p4hir.const #int2_b8i
+          %mask = p4hir.mask(%c1_b8i, %c2_b8i) : !p4hir.set<!b8i>
+          p4hir.yield %mask : !p4hir.set<!b8i>
+        } to @prs::@parse_two
+        p4hir.select_case {
+          %everything = p4hir.const #everything
+          p4hir.yield %everything : !p4hir.set<!p4hir.dontcare>
+        } to @prs::@parse_bottom
+      }
+    }
+// CHECK:    bmv2ir.state @parse_headers
+// CHECK:     transition_key {
+// CHECK:      bmv2ir.lookahead<0, 8>
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  hexstr value #int1_b8i next_state @prs::@parse_one
+// CHECK:      bmv2ir.transition type  hexstr value #int2_b8i next_state @prs::@parse_two
+// CHECK:      bmv2ir.transition type  hexstr value #int1_b8i mask #int2_b8i next_state @prs::@parse_two
+// CHECK:      bmv2ir.transition type  default next_state @prs::@parse_bottom
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:    }
+    p4hir.state @parse_one {
+      %one_field_ref = p4hir.struct_field_ref %arg1["one"] : <!Headers_t>
+      p4corelib.extract_header %one_field_ref : <!header_one> from %arg0 : !p4corelib.packet_in
+      p4hir.transition to @prs::@parse_two
+    }
+// CHECK:    bmv2ir.state @parse_one
+// CHECK:     transition_key {
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  default next_state @prs::@parse_two
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:      bmv2ir.extract  regular "one"
+// CHECK:    }
+    p4hir.state @parse_two {
+      %two_field_ref = p4hir.struct_field_ref %arg1["two"] : <!Headers_t>
+      p4corelib.extract_header %two_field_ref : <!header_two> from %arg0 : !p4corelib.packet_in
+      //p4hir.transition to @prs::@parse_headers
+      p4hir.transition to @prs::@parse_bottom
+    }
+// CHECK:    bmv2ir.state @parse_two
+// CHECK:     transition_key {
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  default next_state @prs::@parse_bottom
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:      bmv2ir.extract  regular "two"
+// CHECK:    }
+    p4hir.state @parse_bottom {
+      p4hir.transition to @prs::@accept
+    }
+// CHECK:    bmv2ir.state @parse_bottom
+// CHECK:     transition_key {
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  default next_state @prs::@accept
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:    }
+    p4hir.state @accept {
+      p4hir.parser_accept
+    }
+// CHECK:    bmv2ir.state @accept
+// CHECK:     transition_key {
+// CHECK:    }
+// CHECK:     transitions {
+// CHECK:      bmv2ir.transition type  default
+// CHECK:    }
+// CHECK:     parser_ops {
+// CHECK:    }
+    p4hir.transition to @prs::@start
+  }
+}


### PR DESCRIPTION
This PR adds an initial implementation for BMv2 Headers and Parser. Only a few parsing constructs are supported, more will be added with follow up PRs.
In order to match the [BMv2 json spec](https://github.com/p4lang/behavioral-model/blob/main/docs/JSON_format.md#parsers), transitions, transition keys and parsing operations are split into three separate regions (with appropriate checks in the verifier) that resemble the final json nodes that we want to emit.