### PR TITLE
Add lowering support for static_assert

### DIFF
--- a/include/p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.td
+++ b/include/p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.td
@@ -102,4 +102,24 @@ def PacketExtractVariableOp : P4CoreLib_Op<"extract_header_variable"> {
     }];
 }
 
+def StaticAssertOp : P4CoreLib_Op<"static_assert"> {
+    let summary = "Compile-time assertion";
+    let description = [{
+        Represents a compile-time assertion. The condition must eventually
+        evaluate to a constant boolean. If the condition is true, this op
+        can be folded away. If false, a separate pass will emit an error.
+        
+        Optionally includes a message string for error reporting.
+    }];
+
+    let arguments = (ins BooleanType:$cond,
+                         OptionalAttr<StrAttr>:$message);
+    let results = (outs BooleanType:$result);
+    let assemblyFormat = [{
+      $cond (`message` $message^)? attr-dict `:` type($cond) `->` type($result)
+    }];
+    
+    let hasFolder = 1;
+}
+
 #endif //P4MLIR_DIALECT_P4CORELIB_P4CORELIB_OPS_TD

--- a/include/p4mlir/Transforms/Passes.h
+++ b/include/p4mlir/Transforms/Passes.h
@@ -25,6 +25,7 @@ namespace P4::P4MLIR {
 #define GEN_PASS_DECL_INLINECONTROLS
 #define GEN_PASS_DECL_EXPANDEMIT
 #define GEN_PASS_DECL_SYMBOLDCE
+#define GEN_PASS_DECL_EVALUATESTATICASSERT
 #include "p4mlir/Transforms/Passes.h.inc"
 
 std::unique_ptr<mlir::Pass> createPrintParsersGraphPass();
@@ -40,6 +41,7 @@ std::unique_ptr<mlir::Pass> createInlineParsersPass();
 std::unique_ptr<mlir::Pass> createInlineControlsPass();
 std::unique_ptr<mlir::Pass> createExpandEmitPass();
 std::unique_ptr<mlir::Pass> createSymbolDCEPass();
+std::unique_ptr<mlir::Pass> createEvaluateStaticAssertPass();
 
 #define GEN_PASS_REGISTRATION
 #include "p4mlir/Transforms/Passes.h.inc"

--- a/include/p4mlir/Transforms/Passes.td
+++ b/include/p4mlir/Transforms/Passes.td
@@ -344,4 +344,24 @@ def SymbolDCE : Pass<"p4hir-symbol-dce"> {
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// EvaluateStaticAssert
+//===----------------------------------------------------------------------===//
+
+def EvaluateStaticAssert : Pass<"p4hir-evaluate-static-assert", "mlir::ModuleOp"> {
+  let summary = "Evaluate static_assert operations";
+  let description = [{
+    Evaluates p4corelib.static_assert operations at compile time:
+    - If condition is constant true: removes the assertion (replaces with constant true)
+    - If condition is constant false: emits compile-time error
+    - If condition is not yet constant: leaves for later evaluation
+  }];
+
+  let constructor = "P4MLIR::createEvaluateStaticAssertPass()";
+  let dependentDialects = [
+    "P4MLIR::P4CoreLib::P4CoreLibDialect",
+    "P4MLIR::P4HIR::P4HIRDialect"
+  ];
+}
+
 #endif // P4MLIR_TRANSFORMS_PASSES_TD

--- a/lib/Conversion/P4HIRToCoreLib/P4HIRToCoreLib.cpp
+++ b/lib/Conversion/P4HIRToCoreLib/P4HIRToCoreLib.cpp
@@ -85,31 +85,31 @@ struct CallOpConversionPattern : public OpConversionPattern<P4HIR::CallOp> {
                                                              operands.getArgOperands());
             return success();
         }
-        // Handle static_assert: compile-time assertion
+        // Handle static_assert: lower to P4CoreLib::StaticAssertOp
         if (callee.getLeafReference().getValue().starts_with("static_assert")) {
             auto args = operands.getArgOperands();
         
             if (args.empty())
                 return op.emitError("static_assert requires a condition");
         
-            // Ensure the condition is a compile-time constant
-            Attribute constAttr;
-            if (!matchPattern(args[0], m_Constant(&constAttr)))
-                return op.emitError("static_assert condition must be constant");
-        
-            // Ensure the constant is boolean
-            auto boolAttr = llvm::dyn_cast<P4HIR::BoolAttr>(constAttr);
-            if (!boolAttr)
-                return op.emitError("static_assert condition must be boolean");
-        
-            // If condition is false, emit compile-time error
-            if (!boolAttr.getValue())
-                return op.emitError("static assertion failed");
-        
-            // If condition is true, replace the call with a constant true
-            auto trueAttr = P4HIR::BoolAttr::get(rewriter.getContext(), true);
-            rewriter.replaceOpWithNewOp<P4HIR::ConstOp>(op, trueAttr);
-        
+            Value cond = args[0];
+            StringAttr message = nullptr;
+            if (args.size() == 2) {
+                if (auto constOp = args[1].getDefiningOp<P4HIR::ConstOp>()) {
+                    message = llvm::dyn_cast<StringAttr>(constOp.getValue());
+                }
+                 if (!message) {
+                    op.emitWarning("static_assert message is not a compile-time constant; ignoring");
+                 }
+                
+            }
+              
+            rewriter.replaceOpWithNewOp<P4CoreLib::StaticAssertOp>(
+                op,
+                op.getResult().getType(),
+                cond,
+                message
+            );
             return success();
         }
 

--- a/lib/Conversion/P4HIRToCoreLib/P4HIRToCoreLib.cpp
+++ b/lib/Conversion/P4HIRToCoreLib/P4HIRToCoreLib.cpp
@@ -4,6 +4,7 @@
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/LogicalResult.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -82,6 +83,33 @@ struct CallOpConversionPattern : public OpConversionPattern<P4HIR::CallOp> {
         if (callee.getLeafReference() == "verify") {
             rewriter.replaceOpWithNewOp<P4CoreLib::VerifyOp>(op, mlir::TypeRange(),
                                                              operands.getArgOperands());
+            return success();
+        }
+        // Handle static_assert: compile-time assertion
+        if (callee.getLeafReference().getValue().starts_with("static_assert")) {
+            auto args = operands.getArgOperands();
+        
+            if (args.empty())
+                return op.emitError("static_assert requires a condition");
+        
+            // Ensure the condition is a compile-time constant
+            Attribute constAttr;
+            if (!matchPattern(args[0], m_Constant(&constAttr)))
+                return op.emitError("static_assert condition must be constant");
+        
+            // Ensure the constant is boolean
+            auto boolAttr = llvm::dyn_cast<P4HIR::BoolAttr>(constAttr);
+            if (!boolAttr)
+                return op.emitError("static_assert condition must be boolean");
+        
+            // If condition is false, emit compile-time error
+            if (!boolAttr.getValue())
+                return op.emitError("static assertion failed");
+        
+            // If condition is true, replace the call with a constant true
+            auto trueAttr = P4HIR::BoolAttr::get(rewriter.getContext(), true);
+            rewriter.replaceOpWithNewOp<P4HIR::ConstOp>(op, trueAttr);
+        
             return success();
         }
 

--- a/lib/Dialect/P4CoreLib/P4CoreLib_Ops.cpp
+++ b/lib/Dialect/P4CoreLib/P4CoreLib_Ops.cpp
@@ -1,6 +1,7 @@
 #include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.h"
 
 #include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Dialect.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Attrs.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
 
 using namespace mlir;
@@ -12,6 +13,27 @@ void P4CoreLib::PacketLengthOp::getAsmResultNames(mlir::OpAsmSetValueNameFn setN
 
 void P4CoreLib::PacketLookAheadOp::getAsmResultNames(mlir::OpAsmSetValueNameFn setNameFn) {
     setNameFn(getResult(), "lookahead");
+}
+
+OpFoldResult P4CoreLib::StaticAssertOp::fold(FoldAdaptor adaptor) {
+    // This fold handles the true case early during canonicalization, without
+    // needing the full EvaluateStaticAssertPass pipeline. False assertions are
+    // intentionally left unhandled here so the pass can emit proper error messages.
+    auto condAttr = adaptor.getCond();
+    if (!condAttr)
+        return {};  // Condition not constant yet
+
+    auto boolAttr = llvm::dyn_cast<P4HIR::BoolAttr>(condAttr);
+    if (!boolAttr)
+        return {};  // Not a boolean
+
+    if (boolAttr.getValue()) {
+        // Assertion passed -> fold to constant true
+        return P4HIR::BoolAttr::get(getContext(), true);
+    }
+
+    // Assertion failed -> seperate pass will handle the error
+    return {};
 }
 
 void P4CoreLib::P4CoreLibDialect::initialize() {

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(P4MLIRTransforms
   EnumElimination.cpp
+  EvaluateStaticAssert.cpp
   FlattenCFG.cpp
   IRUtils.cpp
   InlineParserControl.cpp

--- a/lib/Transforms/EvaluateStaticAssert.cpp
+++ b/lib/Transforms/EvaluateStaticAssert.cpp
@@ -1,0 +1,69 @@
+#include "p4mlir/Transforms/Passes.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Dialect.h"
+#include "p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Attrs.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
+#include "p4mlir/Dialect/P4HIR/P4HIR_Ops.h"
+
+using namespace mlir;
+
+namespace P4::P4MLIR {
+
+#define GEN_PASS_DEF_EVALUATESTATICASSERT
+#include "p4mlir/Transforms/Passes.cpp.inc"
+
+namespace {
+
+struct EvaluateStaticAssertPass
+    : public impl::EvaluateStaticAssertBase<EvaluateStaticAssertPass> {
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+    bool hasError = false;
+
+    SmallVector<P4CoreLib::StaticAssertOp> assertOps;
+    moduleOp->walk([&](P4CoreLib::StaticAssertOp op) {
+      assertOps.push_back(op);
+    });
+
+    for (auto op : assertOps) {
+      Value cond = op.getCond();
+
+      auto constOp = cond.getDefiningOp<P4HIR::ConstOp>();
+      if (!constOp)
+        continue;
+
+      auto boolAttr = llvm::dyn_cast<P4HIR::BoolAttr>(constOp.getValue());
+      if (!boolAttr)
+        continue;
+
+      if (boolAttr.getValue()) {
+        OpBuilder builder(op);
+        auto trueAttr = P4HIR::BoolAttr::get(op.getContext(), true);
+        auto replacement = builder.create<P4HIR::ConstOp>(op.getLoc(), trueAttr);
+        op.replaceAllUsesWith(replacement.getResult());
+        op.erase();
+      } else {
+        if (auto msg = op.getMessage())
+          op.emitError() << "static assertion failed: " << msg.value();
+        else
+          op.emitError("static assertion failed");
+        hasError = true;
+      }
+    }
+
+    if (hasError)
+      signalPassFailure();
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<Pass> createEvaluateStaticAssertPass() {
+  return std::make_unique<EvaluateStaticAssertPass>();
+}
+
+}  // namespace P4::P4MLIR

--- a/test/Conversion/P4CoreLib/static_assert.mlir
+++ b/test/Conversion/P4CoreLib/static_assert.mlir
@@ -1,0 +1,79 @@
+// RUN: p4mlir-opt %s --lower-to-p4corelib --split-input-file -verify-diagnostics
+
+// CASE 1: static_assert(true)
+!string = !p4hir.string
+#true = #p4hir.bool<true> : !p4hir.bool
+#undir = #p4hir<dir undir>
+
+module {
+  p4hir.func @static_assert_1(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"}) -> !p4hir.bool annotations {corelib}
+
+  p4hir.func @test_true_single() -> !p4hir.bool {
+    %true = p4hir.const #true
+    %result = p4hir.call @static_assert_1(%true) : (!p4hir.bool) -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}
+
+// -----
+
+// CASE 2: static_assert(true, "message")
+!string = !p4hir.string
+#true = #p4hir.bool<true> : !p4hir.bool
+#undir = #p4hir<dir undir>
+
+module {
+  p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"},
+                              !string {p4hir.dir = #undir, p4hir.param_name = "message"})
+      -> !p4hir.bool annotations {corelib}
+
+  p4hir.func @test_true_with_message() -> !p4hir.bool {
+    %true = p4hir.const #true
+    %msg = p4hir.const "version check" : !string
+    %result = p4hir.call @static_assert_0(%true, %msg)
+        : (!p4hir.bool, !string) -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}
+
+// -----
+
+// ERROR CASE 1: static_assert(false)
+#false = #p4hir.bool<false> : !p4hir.bool
+#undir = #p4hir<dir undir>
+
+module {
+  p4hir.func @static_assert_1(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"})
+      -> !p4hir.bool annotations {corelib}
+
+  p4hir.func @test_false() -> !p4hir.bool {
+    %false = p4hir.const #false
+    // expected-error @below {{static assertion failed}}
+    // expected-error @below {{failed to legalize operation 'p4hir.call'}}
+    %result = p4hir.call @static_assert_1(%false) : (!p4hir.bool) -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}
+
+// -----
+
+// ERROR CASE 2: static_assert(false, "message")
+!string = !p4hir.string
+#false = #p4hir.bool<false> : !p4hir.bool
+#undir = #p4hir<dir undir>
+
+module {
+  p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"},
+                              !string {p4hir.dir = #undir, p4hir.param_name = "message"})
+      -> !p4hir.bool annotations {corelib}
+
+  p4hir.func @test_false_with_message() -> !p4hir.bool {
+    %false = p4hir.const #false
+    %msg = p4hir.const "this should fail" : !string
+    // expected-error @below {{static assertion failed}}
+    // expected-error @below {{failed to legalize operation 'p4hir.call'}}
+    %result = p4hir.call @static_assert_0(%false, %msg)
+        : (!p4hir.bool, !string) -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}

--- a/test/Conversion/P4CoreLib/static_assert.mlir
+++ b/test/Conversion/P4CoreLib/static_assert.mlir
@@ -1,79 +1,44 @@
-// RUN: p4mlir-opt %s --lower-to-p4corelib --split-input-file -verify-diagnostics
+// RUN: p4mlir-opt %s --lower-to-p4corelib | FileCheck %s
 
-// CASE 1: static_assert(true)
+// Test lowering of static_assert calls to p4corelib.static_assert op
+
 !string = !p4hir.string
 #true = #p4hir.bool<true> : !p4hir.bool
+#false = #p4hir.bool<false> : !p4hir.bool
 #undir = #p4hir<dir undir>
 
 module {
+  p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"}, !string {p4hir.dir = #undir, p4hir.param_name = "message"}) -> !p4hir.bool annotations {corelib}
   p4hir.func @static_assert_1(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"}) -> !p4hir.bool annotations {corelib}
 
-  p4hir.func @test_true_single() -> !p4hir.bool {
+  // Test: static_assert(bool) - single argument form
+  // CHECK-LABEL: @test_single_arg
+  // CHECK: %[[C:.*]] = p4hir.const
+  // CHECK: %[[R:.*]] = p4corelib.static_assert %[[C]]
+  p4hir.func @test_single_arg() -> !p4hir.bool {
     %true = p4hir.const #true
     %result = p4hir.call @static_assert_1(%true) : (!p4hir.bool) -> !p4hir.bool
     p4hir.return %result : !p4hir.bool
   }
-}
 
-// -----
-
-// CASE 2: static_assert(true, "message")
-!string = !p4hir.string
-#true = #p4hir.bool<true> : !p4hir.bool
-#undir = #p4hir<dir undir>
-
-module {
-  p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"},
-                              !string {p4hir.dir = #undir, p4hir.param_name = "message"})
-      -> !p4hir.bool annotations {corelib}
-
-  p4hir.func @test_true_with_message() -> !p4hir.bool {
+  // Test: static_assert(bool, string) - two argument form
+  // CHECK-LABEL: @test_with_message
+  // CHECK: %[[C:.*]] = p4hir.const
+  // CHECK: %[[R:.*]] = p4corelib.static_assert %[[C]]
+  p4hir.func @test_with_message() -> !p4hir.bool {
     %true = p4hir.const #true
-    %msg = p4hir.const "version check" : !string
-    %result = p4hir.call @static_assert_0(%true, %msg)
-        : (!p4hir.bool, !string) -> !p4hir.bool
+    %msg = p4hir.const "compile-time check" : !string
+    %result = p4hir.call @static_assert_0(%true, %msg) : (!p4hir.bool, !string) -> !p4hir.bool
     p4hir.return %result : !p4hir.bool
   }
-}
 
-// -----
-
-// ERROR CASE 1: static_assert(false)
-#false = #p4hir.bool<false> : !p4hir.bool
-#undir = #p4hir<dir undir>
-
-module {
-  p4hir.func @static_assert_1(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"})
-      -> !p4hir.bool annotations {corelib}
-
-  p4hir.func @test_false() -> !p4hir.bool {
+  // Test: lowering works regardless of condition value
+  // CHECK-LABEL: @test_false_lowering
+  // CHECK: %[[C:.*]] = p4hir.const
+  // CHECK: %[[R:.*]] = p4corelib.static_assert %[[C]]
+  p4hir.func @test_false_lowering() -> !p4hir.bool {
     %false = p4hir.const #false
-    // expected-error @below {{static assertion failed}}
-    // expected-error @below {{failed to legalize operation 'p4hir.call'}}
     %result = p4hir.call @static_assert_1(%false) : (!p4hir.bool) -> !p4hir.bool
-    p4hir.return %result : !p4hir.bool
-  }
-}
-
-// -----
-
-// ERROR CASE 2: static_assert(false, "message")
-!string = !p4hir.string
-#false = #p4hir.bool<false> : !p4hir.bool
-#undir = #p4hir<dir undir>
-
-module {
-  p4hir.func @static_assert_0(!p4hir.bool {p4hir.dir = #undir, p4hir.param_name = "check"},
-                              !string {p4hir.dir = #undir, p4hir.param_name = "message"})
-      -> !p4hir.bool annotations {corelib}
-
-  p4hir.func @test_false_with_message() -> !p4hir.bool {
-    %false = p4hir.const #false
-    %msg = p4hir.const "this should fail" : !string
-    // expected-error @below {{static assertion failed}}
-    // expected-error @below {{failed to legalize operation 'p4hir.call'}}
-    %result = p4hir.call @static_assert_0(%false, %msg)
-        : (!p4hir.bool, !string) -> !p4hir.bool
     p4hir.return %result : !p4hir.bool
   }
 }

--- a/test/Transforms/Passes/evaluate-static-assert-error.mlir
+++ b/test/Transforms/Passes/evaluate-static-assert-error.mlir
@@ -1,0 +1,14 @@
+// RUN: not p4mlir-opt %s --p4hir-evaluate-static-assert 2>&1 | FileCheck %s
+
+// Test: static_assert(false) emits compile-time error
+
+#false = #p4hir.bool<false> : !p4hir.bool
+
+module {
+  // CHECK: error: static assertion failed
+  p4hir.func @test_false_error() -> !p4hir.bool {
+    %false = p4hir.const #false
+    %result = p4corelib.static_assert %false : !p4hir.bool -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}

--- a/test/Transforms/Passes/evaluate-static-assert.mlir
+++ b/test/Transforms/Passes/evaluate-static-assert.mlir
@@ -1,0 +1,25 @@
+// RUN: p4mlir-opt %s --p4hir-evaluate-static-assert | FileCheck %s
+
+// Test: static_assert(true) is removed by EvaluateStaticAssertPass
+
+#true = #p4hir.bool<true> : !p4hir.bool
+
+module {
+  // CHECK-LABEL: @test_true_removed
+  // CHECK-NOT: p4corelib.static_assert
+  // CHECK: p4hir.return
+  p4hir.func @test_true_removed() -> !p4hir.bool {
+    %true = p4hir.const #true
+    %result = p4corelib.static_assert %true : !p4hir.bool -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+
+  // Test: non-constant condition is left unchanged
+  // CHECK-LABEL: @test_non_constant_unchanged
+  // CHECK: p4corelib.static_assert
+  p4hir.func @test_non_constant_unchanged(%arg0: !p4hir.bool) -> !p4hir.bool {
+    %result = p4corelib.static_assert %arg0 : !p4hir.bool -> !p4hir.bool
+    p4hir.return %result : !p4hir.bool
+  }
+}
+


### PR DESCRIPTION
issue #183 
Add lowering support for static_assert in the P4HIRToCoreLib conversion.
First I evaluates the assertion condition at compile time. If the condition is a constant boolean true, the call is replaced with p4hir.const #true. If the condition evaluates to false, a diagnostic (static assertion failed) is emitted during lowering.

Covers Four Test cases 
- static_assert(true)
- static_assert(true, "message")
- static_assert(false)
- static_assert(false, "message")

I am using '--split-input-file' to run each cases in an independent module otherwise repeated definations of 'static_assert' will cause duplicate symbol errors.