### PR TITLE
Add verifier checks for UnaryOp operand types

### DIFF
--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -290,12 +290,22 @@ static P4HIR::BinOp getDefiningBinop(P4HIR::BinOpKind kind, mlir::Value val) {
 }
 
 LogicalResult P4HIR::UnaryOp::verify() {
+    auto type = getInput().getType();
+
     switch (getKind()) {
         case P4HIR::UnaryOpKind::Neg:
         case P4HIR::UnaryOpKind::UPlus:
+            if (!mlir::isa<P4HIR::BitsType,P4HIR::InfIntType>(type))
+                return emitOpError("arithmetic unary operations require integer-like type");
+            return success();
         case P4HIR::UnaryOpKind::Cmpl:
+            if (!mlir::isa<P4HIR::BitsType,P4HIR::InfIntType>(type))
+                return emitOpError("bitwise complement operations require integer-like type");
+            return success();
+
         case P4HIR::UnaryOpKind::LNot:
-            // Nothing to verify.
+            if (!mlir::isa<P4HIR::BoolType>(type))
+                return emitOpError("logical not requires boolean type");
             return success();
     }
 

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -299,8 +299,8 @@ LogicalResult P4HIR::UnaryOp::verify() {
                 return emitOpError("arithmetic unary operations require integer-like type");
             return success();
         case P4HIR::UnaryOpKind::Cmpl:
-            if (!mlir::isa<P4HIR::BitsType,P4HIR::InfIntType>(type))
-                return emitOpError("bitwise complement operations require integer-like type");
+            if (!mlir::isa<P4HIR::BitsType>(type))
+                return emitOpError("bitwise complement operations require fixed-width integer type");
             return success();
 
         case P4HIR::UnaryOpKind::LNot:

--- a/test/Dialect/P4HIR/unop-errors.mlir
+++ b/test/Dialect/P4HIR/unop-errors.mlir
@@ -1,0 +1,20 @@
+// RUN: not p4mlir-opt %s 2>&1 | FileCheck %s --check-prefix=ERR
+
+module {
+  %0 = p4hir.const #p4hir.int<1> : !p4hir.int<8>
+  %1 = p4hir.unary(not, %0) : !p4hir.int<8>
+  // ERR: 'p4hir.unary' op logical not requires boolean type
+}
+
+module {
+  %0 = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  %1 = p4hir.unary(minus, %0) : !p4hir.bool
+  // ERR: 'p4hir.unary' op arithmetic unary operations require integer-like type
+}
+
+module {
+  %0 = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  %1 = p4hir.unary(cmpl, %0) : !p4hir.bool
+  // ERR: 'p4hir.unary' op bitwise complement operations require integer-like type
+}
+

--- a/test/Dialect/P4HIR/unop-errors.mlir
+++ b/test/Dialect/P4HIR/unop-errors.mlir
@@ -15,6 +15,6 @@ module {
 module {
   %0 = p4hir.const #p4hir.bool<true> : !p4hir.bool
   %1 = p4hir.unary(cmpl, %0) : !p4hir.bool
-  // ERR: 'p4hir.unary' op bitwise complement operations require integer-like type
+  // ERR: 'p4hir.unary' op bitwise complement operations require fixed-width integer type
 }
 


### PR DESCRIPTION
This change tightens `p4hir.unary` verification by enforcing operand type constraints based on the unary operation kind.

Changes:
- require `not` to operate on `!p4hir.bool`
- require `minus`, `plus`, and `cmpl` to operate on integer-like P4HIR bit types

Also adds a negative test file covering invalid unary operations.

Validation:
- `ninja check-p4mlir` passes

Fixes: FIXME in UnaryOp verifier