### PR TITLE
Generalize operations to work with any struct-like type

### DIFF
--- a/include/p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.td
+++ b/include/p4mlir/Dialect/P4CoreLib/P4CoreLib_Ops.td
@@ -50,7 +50,7 @@ def PacketEmitOp : P4CoreLib_Op<"emit"> {
     }];
 
     let arguments = (ins Arg<PacketOutType, "packet buffer", [PacketOutWrite]>:$packet_out,
-                         StructLikeType:$hdr);
+                         StructLikeTypeInterface:$hdr);
     let assemblyFormat = [{
       $hdr `:` type($hdr) `to` $packet_out `:` type($packet_out) attr-dict
     }];

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1074,7 +1074,7 @@ def StructOp : P4HIR_Op<"struct",
   let summary = "Create a struct from constituent parts.";
   // FIXME: Better constraint type
   let arguments = (ins Variadic<AnyP4Type>:$input);
-  let results = (outs StructLikeType:$result);
+  let results = (outs StructLikeTypeInterface:$result);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
@@ -1093,7 +1093,7 @@ def StructExtractOp : P4HIR_Op<"struct_extract",
     ```
   }];
 
-  let arguments = (ins StructLikeType:$input, I32Attr:$fieldIndex);
+  let arguments = (ins StructLikeTypeInterface:$input, I32Attr:$fieldIndex);
   // FIXME: Better constraint type
   let results = (outs AnyP4Type:$result);
   let hasCustomAssemblyFormat = 1;

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.h
@@ -13,7 +13,20 @@
 
 namespace P4::P4MLIR::P4HIR {
 mlir::TypedAttr getStructLikeDefaultValue(StructLikeTypeInterface type);
-}
+
+void printFieldInfo(mlir::AsmPrinter &p, const FieldInfo &fi);
+mlir::ParseResult parseFieldInfo(mlir::AsmParser &p, mlir::FailureOr<FieldInfo> &fi);
+
+/// Parse a list of unique field names and types within <> plus name. E.g.:
+/// <name, foo: i7, bar: i8>
+mlir::ParseResult parseFields(mlir::AsmParser &p, std::string &name,
+                              llvm::SmallVectorImpl<FieldInfo> &parameters,
+                              mlir::DictionaryAttr &annotations);
+
+/// Print out a list of named fields surrounded by <>.
+void printFields(mlir::AsmPrinter &p, llvm::StringRef name, llvm::ArrayRef<FieldInfo> fields,
+                 mlir::DictionaryAttr annotations);
+}  // namespace P4::P4MLIR::P4HIR
 
 #define GET_TYPEDEF_CLASSES
 #include "p4mlir/Dialect/P4HIR/P4HIR_Types.h.inc"

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -957,24 +957,23 @@ def ArrayType : P4HIR_Type<"Array", "array", [
 //===----------------------------------------------------------------------===//
 
 def AnyP4Type : AnyTypeOf<[BitsType, VarBitsType, BooleanType, InfIntType, StringType,
-                           StructType, HeaderType, HeaderUnionType, HeaderStackType, Builtin_Tuple,
+                           StructLikeTypeInterface, Builtin_Tuple,
                            EnumType, SerEnumType,
                            ValidBitType,
                            DontcareType, ErrorType, UnknownType, AliasType,
                            SetType, ArrayType]> {}
 def AnyIntP4Type : AnyTypeOf<[BitsType, InfIntType]> {}
 def CallResultP4Type : AnyTypeOf<[BitsType, BooleanType, InfIntType, VoidType,
-                                  StructType, HeaderType, Builtin_Tuple,
+                                  StructLikeTypeInterface, Builtin_Tuple,
                                   EnumType, SerEnumType, AliasType,
                                   ExternType]> {}
 def LoadableP4Type : AnyTypeOf<[BitsType, VarBitsType, BooleanType, InfIntType,
-                                StructType, HeaderType, HeaderUnionType, HeaderStackType, Builtin_Tuple,
+                                StructLikeTypeInterface, Builtin_Tuple,
                                 EnumType, SerEnumType, ErrorType,
                                 ValidBitType, AliasType, ArrayType]> {}
 def AnyEnumType : AnyTypeOf<[EnumType, SerEnumType]>;
 def AnyCollectionType : AnyTypeOf<[HeaderStackType, SetType, ArrayType]> {}
 def SwitchCondType : AnyTypeOf<[AnyIntP4Type, AnyEnumType, ErrorType]>;
-def StructLikeType : AnyTypeOf<[StructType, HeaderType, HeaderUnionType, HeaderStackType]>;
 def P4ObjectType : AnyTypeOf<[ParserType, ControlType, ExternType, PackageType]>;
 
 /// A ref type with the specified constraints on the nested type.
@@ -987,7 +986,7 @@ class SpecificRefType<Type type> : ConfinedType<ReferenceType,
 }
 
 def StructRefType : SpecificRefType<StructType>;
-def StructLikeRefType : SpecificRefType<StructLikeType>;
+def StructLikeRefType : SpecificRefType<StructLikeTypeInterface>;
 def BitsRefType : SpecificRefType<BitsType>;
 def HeaderRefType : SpecificRefType<HeaderType>;
 def ArrayRefType : SpecificRefType<ArrayType>;

--- a/lib/Dialect/P4HIR/P4HIR_Types.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Types.cpp
@@ -31,8 +31,6 @@ static mlir::ParseResult parseCtorType(
     mlir::AsmParser &p, llvm::SmallVector<std::pair<mlir::StringAttr, mlir::Type>> &params,
     mlir::Type &resultType);
 
-static mlir::ParseResult parseFieldInfo(mlir::AsmParser &p, FailureOr<FieldInfo> &fi);
-
 static mlir::ParseResult parseArray(mlir::AsmParser &p, size_t &size, mlir::Type &elementType);
 
 static void printFuncType(mlir::AsmPrinter &p, mlir::ArrayRef<mlir::Type> params,
@@ -40,7 +38,6 @@ static void printFuncType(mlir::AsmPrinter &p, mlir::ArrayRef<mlir::Type> params
 static void printCtorType(mlir::AsmPrinter &p,
                           mlir::ArrayRef<std::pair<mlir::StringAttr, mlir::Type>> params,
                           mlir::Type resultType);
-static void printFieldInfo(mlir::AsmPrinter &p, const FieldInfo &fi);
 static void printArray(mlir::AsmPrinter &p, size_t size, mlir::Type elementType);
 static void printArray(mlir::AsmPrinter &p, ArrayType arrayType);
 
@@ -239,10 +236,11 @@ bool FuncType::isVoid() const {
     return !rt;
 }
 
-static ParseResult parseFieldInfo(AsmParser &p, FailureOr<FieldInfo> &field) {
+namespace P4::P4MLIR::P4HIR {
+mlir::ParseResult parseFieldInfo(mlir::AsmParser &p, mlir::FailureOr<FieldInfo> &field) {
     // Parse fields
     std::string fieldName;
-    Type fieldType;
+    mlir::Type fieldType;
     mlir::NamedAttrList fieldAnnotations;
 
     if (p.parseKeywordOrString(&fieldName) || p.parseColon() || p.parseType(fieldType) ||
@@ -255,17 +253,15 @@ static ParseResult parseFieldInfo(AsmParser &p, FailureOr<FieldInfo> &field) {
     return success();
 }
 
-/// Parse a list of unique field names and types within <> plus name. E.g.:
-/// <name, foo: i7, bar: i8>
-static ParseResult parseFields(AsmParser &p, std::string &name,
-                               SmallVectorImpl<FieldInfo> &parameters,
-                               mlir::DictionaryAttr &annotations) {
+mlir::ParseResult parseFields(mlir::AsmParser &p, std::string &name,
+                              llvm::SmallVectorImpl<FieldInfo> &parameters,
+                              mlir::DictionaryAttr &annotations) {
     llvm::StringSet<> nameSet;
     mlir::NamedAttrList annList;
     bool hasDuplicateName = false;
     bool parsedName = false;
-    auto parseResult =
-        p.parseCommaSeparatedList(mlir::AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
+    auto parseResult = p.parseCommaSeparatedList(
+        mlir::AsmParser::Delimiter::LessGreater, [&]() -> mlir::ParseResult {
             // First, try to parse name
             if (!parsedName) {
                 if (p.parseKeywordOrString(&name) || p.parseOptionalAttrDict(annList))
@@ -276,7 +272,7 @@ static ParseResult parseFields(AsmParser &p, std::string &name,
             }
 
             // Parse fields
-            FailureOr<FieldInfo> field;
+            mlir::FailureOr<FieldInfo> field;
             auto fieldLoc = p.getCurrentLocation();
             if (parseFieldInfo(p, field)) return failure();
 
@@ -295,7 +291,7 @@ static ParseResult parseFields(AsmParser &p, std::string &name,
     return parseResult;
 }
 
-static void printFieldInfo(AsmPrinter &p, const FieldInfo &field) {
+void printFieldInfo(mlir::AsmPrinter &p, const FieldInfo &field) {
     p.printKeywordOrString(field.name.getValue());
     p << ": " << field.type;
     if (field.annotations && !field.annotations.empty()) {
@@ -304,9 +300,8 @@ static void printFieldInfo(AsmPrinter &p, const FieldInfo &field) {
     }
 }
 
-/// Print out a list of named fields surrounded by <>.
-static void printFields(AsmPrinter &p, StringRef name, ArrayRef<FieldInfo> fields,
-                        mlir::DictionaryAttr annotations) {
+void printFields(mlir::AsmPrinter &p, llvm::StringRef name, llvm::ArrayRef<FieldInfo> fields,
+                 mlir::DictionaryAttr annotations) {
     p << '<';
     p.printString(name);
     if (annotations && !annotations.empty()) {
@@ -317,6 +312,7 @@ static void printFields(AsmPrinter &p, StringRef name, ArrayRef<FieldInfo> field
     llvm::interleaveComma(fields, p, [&](const FieldInfo &field) { printFieldInfo(p, field); });
     p << ">";
 }
+}  // namespace P4::P4MLIR::P4HIR
 
 Type StructType::parse(AsmParser &p) {
     llvm::SmallVector<FieldInfo, 4> parameters;

--- a/lib/Transforms/ExpandEmit.cpp
+++ b/lib/Transforms/ExpandEmit.cpp
@@ -30,41 +30,51 @@ struct ExpandEmitPass : public P4::P4MLIR::impl::ExpandEmitBase<ExpandEmitPass> 
 
 struct ExpandEmitPattern : public mlir::OpRewritePattern<P4CoreLib::PacketEmitOp> {
     explicit ExpandEmitPattern(MLIRContext *context) : OpRewritePattern(context) {}
+
     mlir::LogicalResult matchAndRewrite(P4CoreLib::PacketEmitOp emitOp,
                                         mlir::PatternRewriter &rewriter) const override {
         auto dstPkt = emitOp.getPacketOut();
         auto emitArg = emitOp.getHdr();
         auto loc = emitOp.getLoc();
-        return llvm::TypeSwitch<mlir::Type, mlir::LogicalResult>(emitArg.getType())
-            .Case<P4HIR::HeaderUnionType, P4HIR::StructType>([&](auto tp) {
-                auto elements = tp.getFields();
-                for (const auto &elt : elements) {
-                    auto extrData = rewriter.create<P4HIR::StructExtractOp>(loc, emitArg, elt.name);
-                    rewriter.create<P4CoreLib::PacketEmitOp>(loc, dstPkt, extrData);
-                }
-                rewriter.eraseOp(emitOp);
-                return mlir::success();
+
+        return mlir::TypeSwitch<mlir::Type, mlir::LogicalResult>(emitArg.getType())
+            .Case<P4HIR::HeaderType>([&](mlir::Type) {
+                // Nothing to do for plain header.
+                return mlir::failure();
             })
-            .Case<P4HIR::HeaderStackType>([&](P4HIR::HeaderStackType tp) {
+            .Case<P4HIR::HeaderUnionType, P4HIR::StructType>(
+                [&](P4HIR::StructLikeTypeInterface tp) -> mlir::LogicalResult {
+                    auto elements = tp.getFields();
+                    for (const auto &elt : elements) {
+                        auto extrData =
+                            rewriter.create<P4HIR::StructExtractOp>(loc, emitArg, elt.name);
+                        if (!mlir::isa<P4HIR::StructLikeTypeInterface>(extrData.getType()))
+                            return emitOp.emitOpError() << "Invalid type contained in emit call";
+                        rewriter.create<P4CoreLib::PacketEmitOp>(loc, dstPkt, extrData);
+                    }
+                    rewriter.eraseOp(emitOp);
+                    return mlir::success();
+                })
+            .Case<P4HIR::HeaderStackType>([&](mlir::Type) -> mlir::LogicalResult {
                 auto hsData = rewriter.create<P4HIR::StructExtractOp>(
                     loc, emitArg, P4HIR::HeaderStackType::dataFieldName);
-                rewriter.create<P4CoreLib::PacketEmitOp>(loc, dstPkt, hsData);
-                rewriter.eraseOp(emitOp);
-                return mlir::success();
-            })
-            .Case<P4HIR::ArrayType>([&](P4HIR::ArrayType tp) {
+                auto arrayType = mlir::cast<P4HIR::ArrayType>(hsData.getType());
                 static constexpr unsigned hsIdBitWidth = 32;
                 auto intType = P4HIR::BitsType::get(getContext(), hsIdBitWidth, false);
-                for (unsigned i = 0; i < tp.getSize(); i++) {
+                for (unsigned i = 0; i < arrayType.getSize(); i++) {
                     auto idxOp =
                         rewriter.create<P4HIR::ConstOp>(loc, P4HIR::IntAttr::get(intType, i));
-                    auto arrItem = rewriter.create<P4HIR::ArrayGetOp>(loc, emitArg, idxOp);
+                    auto arrItem = rewriter.create<P4HIR::ArrayGetOp>(loc, hsData, idxOp);
+                    if (!mlir::isa<P4HIR::StructLikeTypeInterface>(arrItem.getType()))
+                        return emitOp.emitOpError() << "Invalid type contained in emit call";
                     rewriter.create<P4CoreLib::PacketEmitOp>(loc, dstPkt, arrItem);
                 }
                 rewriter.eraseOp(emitOp);
                 return mlir::success();
             })
-            .Default([](mlir::Type tp) { return mlir::failure(); });
+            .Default([&](mlir::Type) {
+                return emitOp.emitOpError() << "Invalid type contained in emit call";
+            });
     }
 };
 

--- a/test/Dialect/P4CoreLib/emit_struct.mlir
+++ b/test/Dialect/P4CoreLib/emit_struct.mlir
@@ -7,9 +7,8 @@
 !header_one = !p4hir.header<"header_one", type: !b8i, data: !b8i, __valid: !validity_bit>
 !header_two = !p4hir.header<"header_two", type: !b8i, data: !b16i, __valid: !validity_bit>
 !hs_2ht = !p4hir.header_stack<2x!header_two>
-!arr_int = !p4hir.array<2 x !header_two>
 !hu = !p4hir.header_union<"hu", h1: !header_one, h2: !header_two>
-!struct_int = !p4hir.struct<"headers_int", t5: !hu, t6: !arr_int>
+!struct_int = !p4hir.struct<"headers_int", t5: !hu>
 !headers_t = !p4hir.struct<"headers_t", t1: !header_one, t2: !header_two, t3: !struct_int, t4: !hs_2ht>
 module {
   // CHECK-LABEL: emitTest
@@ -27,11 +26,6 @@ module {
       // CHECK: p4corelib.emit %[[H1]] : !header_one to %arg0 : !p4corelib.packet_out
       // CHECK: %[[H2:.*]] = p4hir.struct_extract %[[T5]]["h2"] : !hu
       // CHECK: p4corelib.emit %[[H2]] : !header_two to %arg0 : !p4corelib.packet_out
-      // CHECK: %[[T6:.*]] = p4hir.struct_extract %[[T3]]["t6"] : !headers_int
-      // CHECK: %[[AR0:.*]] = p4hir.array_get %[[T6]][%[[C0]]] : !arr_2xheader_two, !b32i
-      // CHECK: p4corelib.emit %[[AR0]] : !header_two to %arg0 : !p4corelib.packet_out
-      // CHECK: %[[AR1:.*]] = p4hir.array_get %[[T6]][%[[C1]]] : !arr_2xheader_two, !b32i
-      // CHECK: p4corelib.emit %[[AR1]] : !header_two to %arg0 : !p4corelib.packet_out
       // CHECK: %[[T4:.*]] = p4hir.struct_extract %arg1["t4"] : !headers_t
       // CHECK: %[[HSD:.*]] = p4hir.struct_extract %[[T4]]["data"] : !hs_2xheader_two
       // CHECK: %[[AR2:.*]] = p4hir.array_get %[[HSD]][%[[C0]]] : !arr_2xheader_two, !b32i


### PR DESCRIPTION
This PR generalizes operations to work with any type implementing `StructLikeTypeInterface` where appropriate. This makes it easier to extend P4HIR and integrate it with other dialects.

The change of `p4hir.emit` argument type also uncovered a emit lowering issue, where we would lower an type not allowed by the spec (array of headers), which was also included in the test. I have adjusted the pass to fix this.

(I don't think we can get that type from any source code, but nonetheless the new implementation is more specific as to what can be in there).