### PR TITLE
Fold ser_enum roundtrip casts

### DIFF
--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -292,19 +292,22 @@ LogicalResult P4HIR::CastOp::canonicalize(P4HIR::CastOp op, PatternRewriter &rew
         mlir::Type midType = inputCast.getType();
         mlir::Type dstType = op.getType();
 
-        auto isBit1Type = [](mlir::Type type) {
-            auto bitsType = mlir::dyn_cast<P4HIR::BitsType>(type);
-            return bitsType && bitsType.getWidth() == 1 && !bitsType.isSigned();
+        auto validRoundtripPred = [](mlir::Type typeA, mlir::Type typeB) {
+            // Hanldes `bool -> bit<1> -> bool` and `bit<1> -> bool -> bit<1>`
+            auto aBitsType = mlir::dyn_cast<P4HIR::BitsType>(typeA);
+            bool aIsBit1 = (aBitsType && aBitsType.getWidth() == 1 && !aBitsType.isSigned());
+            if (aIsBit1 && mlir::isa<P4HIR::BoolType>(typeB)) return true;
+
+            // Hanldes `type -> ser_enum<type> -> type` and `ser_enum<type> -> type ->
+            // ser_enum<type>`
+            auto bSerEnumType = mlir::dyn_cast<P4HIR::SerEnumType>(typeB);
+            if (bSerEnumType && bSerEnumType.getType() == typeA) return true;
+
+            return false;
         };
 
-        // bool -> bit<1> -> bool roundtrip.
-        if (mlir::isa<P4HIR::BoolType>(srcType) && srcType == dstType && isBit1Type(midType)) {
-            rewriter.replaceOp(op, inputCast.getSrc());
-            return success();
-        }
-
-        // bit<1> -> bool -> bit<1> roundtrip.
-        if (isBit1Type(srcType) && srcType == dstType && mlir::isa<P4HIR::BoolType>(midType)) {
+        if (srcType == dstType &&
+            (validRoundtripPred(srcType, midType) || validRoundtripPred(midType, srcType))) {
             rewriter.replaceOp(op, inputCast.getSrc());
             return success();
         }

--- a/test/Transforms/Folds/cast.mlir
+++ b/test/Transforms/Folds/cast.mlir
@@ -78,9 +78,11 @@ module {
   p4hir.func @blackhole_b8i(!b8i)
   p4hir.func @blackhole_b16i(!b16i)
   p4hir.func @blackhole_b32i(!b32i)
+  p4hir.func @blackhole_b42i(!bit42)
+  p4hir.func @blackhole_SuitsSerializable(!SuitsSerializable)
 
   // Use non-constant arguments so chains are not constant-folded away.
-  p4hir.func @cast_chain_tests(%arg_b8 : !b8i, %arg_b16 : !b16i, %arg_i8 : !i8i, %arg_b32 : !b32i, %arg_b1 : !b1i, %arg_bool : !bool) {
+  p4hir.func @cast_chain_tests(%arg_b8 : !b8i, %arg_b16 : !b16i, %arg_i8 : !i8i, %arg_b32 : !b32i, %arg_b1 : !b1i, %arg_bool : !bool, %arg_serenum : !SuitsSerializable, %arg_b42 : !bit42) {
     // Safe: widen then reinterpret (w_B >= w_C).
     // bit<8> -> bit<16> -> int<16> folds to bit<8> -> int<16>.
     // CHECK-LABEL: @cast_chain_tests
@@ -153,6 +155,18 @@ module {
     %bit1_2 = p4hir.cast(%arg_bool : !bool) : !b1i
     %bool_2 = p4hir.cast(%bit1_2 : !b1i) : !bool
     p4hir.call @blackhole_bool(%bool_2) : (!bool) -> ()
+    
+    // ser_enum -> bits -> ser_enum folds to source.
+    // CHECK: p4hir.call @blackhole_SuitsSerializable (%arg6) : (!Suits) -> ()
+    %bit42_1 = p4hir.cast(%arg_serenum : !SuitsSerializable) : !bit42
+    %suits_1 = p4hir.cast(%bit42_1 : !bit42) : !SuitsSerializable
+    p4hir.call @blackhole_SuitsSerializable(%suits_1) : (!SuitsSerializable) -> ()
+
+    // bits -> ser_enum -> bits folds to source.
+    // CHECK: p4hir.call @blackhole_b42i (%arg7) : (!b42i) -> ()
+    %suits_2 = p4hir.cast(%arg_b42 : !bit42) : !SuitsSerializable
+    %bit42_2 = p4hir.cast(%suits_2 : !SuitsSerializable) : !bit42
+    p4hir.call @blackhole_b42i(%bit42_2) : (!bit42) -> ()
 
     p4hir.return
   }


### PR DESCRIPTION
Improvement after https://github.com/p4lang/p4mlir-incubator/pull/339 to also fold ser_enum / bits roundtrip casts.