### PR TITLE
Fix location in struct extract canonicalization and memory issue

### DIFF
--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -2001,9 +2001,10 @@ LogicalResult P4HIR::StructExtractOp::canonicalize(P4HIR::StructExtractOp op,
                 fieldVal = it->second;
             } else {
                 auto fieldRef = P4HIR::StructFieldRefOp::create(
-                    rewriter, op.getLoc(), P4HIR::ReferenceType::get(structExtract.getType()),
-                    readOp.getRef(), structExtract.getFieldIndexAttr());
-                fieldVal = P4HIR::ReadOp::create(rewriter, op.getLoc(), fieldRef);
+                    rewriter, structExtract.getLoc(),
+                    P4HIR::ReferenceType::get(structExtract.getType()), readOp.getRef(),
+                    structExtract.getFieldIndexAttr());
+                fieldVal = P4HIR::ReadOp::create(rewriter, structExtract.getLoc(), fieldRef);
                 fieldVals.insert({indexAttr, fieldVal});
             }
 


### PR DESCRIPTION
The newly created struct extract ref and read operations in struct extract canonicalization would incorrectly use the location of the initial `op` rather than each `structExtract` that is replaced.

Apart from fixing the wrong location this also fixes a potential invalid memory access to `op.getLoc()` after `op`is deleted, depending on the order of uses.

No test added because the memory issue cannot be reproduced except in specific pass pipelines.