### PR TITLE
Fix duplicate library entry in p4mlir-opt CMakeLists

### DIFF
--- a/tools/p4mlir-opt/CMakeLists.txt
+++ b/tools/p4mlir-opt/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LIBS
   P4MLIR_BMv2IR
   P4MLIRConversion
   P4MLIRTransforms
-  P4MLIRConversion
   P4HIRToBMv2IR
   P4Pipelines
   BMv2Pipelines


### PR DESCRIPTION
This PR removes a duplicate entry of `P4MLIRConversion` from the LIBS list in tools/p4mlir-opt/CMakeLists.txt.

Issue:
The library `P4MLIRConversion` was listed twice in the LIBS variable, which is unnecessary and could lead to redundant linkage configuration.

Fix:
Removed the duplicate entry while keeping all required dependencies intact.

Impact:
- No functional changes
- Cleaned up build configuration
- Avoids duplicate library specification in CMake target linking