### PR TITLE
Remove duplicate P4MLIRConversion in p4mlir-to-json CMakeLists

### DIFF
--- a/tools/p4mlir-to-json/CMakeLists.txt
+++ b/tools/p4mlir-to-json/CMakeLists.txt
@@ -5,7 +5,6 @@ set(LIBS
   P4MLIR_BMv2IR
   P4MLIRConversion
   P4MLIRTransforms
-  P4MLIRConversion
   P4HIRToBMv2IR
   P4Pipelines
   BMv2Pipelines


### PR DESCRIPTION
This PR removes a duplicate entry of P4MLIRConversion from the LIBS list in tools/p4mlir-to-json/CMakeLists.txt.

Issue:
P4MLIRConversion was listed twice in the dependency list.

Fix:
Removed the duplicate occurrence while keeping all required dependencies intact.

Impact:
- No functional changes
- Cleaned up CMake configuration
- Prevents redundant library specification