### PR TITLE
Add missing library to Transforms/CMakeLists.txt

### DIFF
--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_dialect_library(P4MLIRTransforms
   P4MLIRTransformsPassIncGen
 
   LINK_LIBS PUBLIC
+  P4MLIRConversion
   MLIRIR
   MLIRSupport
   MLIRTransforms

--- a/tools/p4mlir-opt/CMakeLists.txt
+++ b/tools/p4mlir-opt/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LIBS
   P4MLIR_BMv2IR
   P4MLIRConversion
   P4MLIRTransforms
-  P4MLIRConversion
   P4HIRToBMv2IR
   P4Pipelines
   BMv2Pipelines

--- a/tools/p4mlir-to-json/CMakeLists.txt
+++ b/tools/p4mlir-to-json/CMakeLists.txt
@@ -5,7 +5,6 @@ set(LIBS
   P4MLIR_BMv2IR
   P4MLIRConversion
   P4MLIRTransforms
-  P4MLIRConversion
   P4HIRToBMv2IR
   P4Pipelines
   BMv2Pipelines


### PR DESCRIPTION
Added missing `P4MLIRConversion` to Transforms/CMakeLists.txt which could cause linking issues when using p4mlir as a library with cmake. Also cleaned duplicate entries in two other CMakeLists files.