### PR TITLE
Generalize ConstOp to allow StructLikeType for aggregates

### DIFF
--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -126,8 +126,7 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     }
 
     if (mlir::isa<P4HIR::AggAttr>(attrType)) {
-        if (!mlir::isa<P4HIR::StructType, P4HIR::HeaderType, P4HIR::HeaderUnionType,
-                       mlir::TupleType, P4HIR::ArrayType>(opType))
+        if (!mlir::isa<P4HIR::StructLikeTypeInterface, mlir::TupleType, P4HIR::ArrayType>(opType))
             return op->emitOpError("result type (") << opType << ") is not an aggregate type";
 
         return success();


### PR DESCRIPTION
Similar to https://github.com/p4lang/p4mlir-incubator/pull/337, generalize aggregate `ConstOp` to allow struct like type result, instead of hardcoded p4mlir list of types. This makes `ConstOp` easier to integrate with external dialects.