### PR TITLE
Handle zero table entries

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_ControlOps.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_ControlOps.td
@@ -319,7 +319,7 @@ def TableEntriesOp : P4HIR_Op<"table_entries", [ Annotated,
   }];
 
   let arguments = (ins UnitAttr:$is_const, OptionalAttr<DictionaryAttr>:$annotations);
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region MaxSizedRegion<1>:$body);
 
   // TODO: Check
   let hasVerifier = 0;

--- a/test/Dialect/P4HIR/table-entries.mlir
+++ b/test/Dialect/P4HIR/table-entries.mlir
@@ -105,6 +105,27 @@ module @p4_main {
         }
       }
     }
+    p4hir.table @t_exact_zero_entries {
+      p4hir.table_key(%arg2: !p4hir.ref<!Header_t>) {
+        %val = p4hir.read %arg2 : <!Header_t>
+        %h = p4hir.struct_extract %val["h"] : !Header_t
+        %e = p4hir.struct_extract %h["e"] : !hdr
+        p4hir.match_key #exact %e : !b8i annotations {name = "h.h.e"}
+      }
+      p4hir.table_actions {
+        p4hir.table_action @a() {
+          p4hir.call @a () : () -> ()
+        }
+        p4hir.table_action @a_with_control_params(%arg2: !b9i {p4hir.param_name = "x"}) {
+          p4hir.call @a_with_control_params (%arg2) : (!b9i) -> ()
+        }
+      }
+      p4hir.table_default_action const {
+        p4hir.call @a () : () -> ()
+      }
+      p4hir.table_entries const {
+      }
+    }
     p4hir.table @t_lpm {
       p4hir.table_key(%arg2: !p4hir.ref<!Header_t>) {
         %val = p4hir.read %arg2 : <!Header_t>


### PR DESCRIPTION
Allow a zero sized region for `table_entries`. This fixes generating IR that does not verify if the user declares `(const) entries = {}`.

I didn't add a canonicalization to eliminate the empty table actions because if they're marked `const` then this encodes a constraint on the control plane side (although it wouldn't make much sense, it's still valid code).

We could eliminate it in the non-const case, but I don't see much value in that. I believe the backend is responsible to properly handle it.