### PR TITLE
Add more useful matchers for constants

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/Matchers.h
+++ b/include/p4mlir/Dialect/P4HIR/Matchers.h
@@ -104,30 +104,69 @@ inline auto m_IntegerExt(Matcher matcher, bool isSigned, bool optional) {
 }
 
 struct ConstantIntBinder {
-    llvm::APSInt *bindValue;
-    unsigned *bindValueInt;
+    enum Kind : unsigned {
+        KindMatchOnly = 0,
+        KindBindAPSInt = 1,
+        KindBindInt = 2,
+        KindMatchAPSint = 3,
+        KindMatchInt = 4,
+    };
+
+    llvm::APSInt *bindValue = nullptr;
+    llvm::APSInt matchValue;
+    unsigned *bindValueInt = nullptr;
+    unsigned matchValueInt = 0;
+    unsigned kind;
     bool matchBool;
 
     ConstantIntBinder(bool matchBool)
-        : bindValue(nullptr), bindValueInt(nullptr), matchBool(matchBool) {}
+        : bindValue(nullptr), bindValueInt(nullptr), kind(KindMatchOnly), matchBool(matchBool) {}
 
     ConstantIntBinder(llvm::APSInt *bindValue, bool matchBool)
-        : bindValue(bindValue), bindValueInt(nullptr), matchBool(matchBool) {}
+        : bindValue(bindValue), kind(KindBindAPSInt), matchBool(matchBool) {}
 
     ConstantIntBinder(unsigned *bindValueInt, bool matchBool)
-        : bindValue(nullptr), bindValueInt(bindValueInt), matchBool(matchBool) {}
+        : bindValueInt(bindValueInt), kind(KindBindInt), matchBool(matchBool) {}
+
+    ConstantIntBinder(llvm::APSInt matchValue, bool matchBool)
+        : matchValue(matchValue), kind(KindMatchAPSint), matchBool(matchBool) {}
+
+    ConstantIntBinder(unsigned matchValueInt, bool matchBool)
+        : matchValueInt(matchValueInt), kind(KindMatchInt), matchBool(matchBool) {}
 
     bool match(mlir::Operation *op) {
         mlir::Attribute attr;
         if (!matchPattern(op, m_Constant(&attr))) return false;
         auto val = P4::P4MLIR::P4HIR::getConstantInt(attr);
         if (!val || (mlir::isa<P4::P4MLIR::P4HIR::BoolAttr>(attr) && !matchBool)) return false;
-        if (bindValue) *bindValue = *val;
-        if (bindValueInt) {
-            if (!val->isIntN(32)) return false;
-            *bindValueInt = val->getLimitedValue();
+
+        switch (kind) {
+            case KindMatchOnly: {
+                return true;
+            }
+            case KindBindAPSInt: {
+                assert(bindValue && "Expected valid pointer");
+                *bindValue = *val;
+                return true;
+            }
+            case KindBindInt: {
+                assert(bindValueInt && "Expected valid pointer");
+                if (!val->isIntN(32)) return false;
+                *bindValueInt = val->getLimitedValue();
+                return true;
+            }
+            case KindMatchAPSint: {
+                return val == matchValue;
+            }
+            case KindMatchInt: {
+                if (!val->isIntN(32)) return false;
+                return val->getLimitedValue() == matchValueInt;
+            }
+            default: {
+                llvm_unreachable("Impossible kind");
+                return false;
+            }
         }
-        return true;
     }
 };
 
@@ -142,6 +181,16 @@ inline auto m_ConstantInt(llvm::APSInt *bindValue, bool matchBool = false) {
 }
 
 inline auto m_ConstantInt(bool matchBool = true) { return detail::ConstantIntBinder(matchBool); }
+
+inline auto m_ConstantInt(unsigned matchValue, bool matchBool = false) {
+    return detail::ConstantIntBinder(matchValue, matchBool);
+}
+
+inline auto m_ConstantInt(llvm::APSInt matchValue, bool matchBool = false) {
+    return detail::ConstantIntBinder(matchValue, matchBool);
+}
+
+inline auto m_ZeroInt(bool matchBool = false) { return m_ConstantInt((unsigned)0, matchBool); }
 
 template <typename Matcher>
 inline auto m_UnaryOp(P4::P4MLIR::P4HIR::UnaryOpKind kind, Matcher matcher) {

--- a/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
@@ -4,6 +4,7 @@
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Interfaces/MemorySlotInterfaces.h"
+#include "p4mlir/Dialect/P4HIR/Matchers.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Attrs.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Dialect.h"
 #include "p4mlir/Dialect/P4HIR/P4HIR_Ops.h"
@@ -307,12 +308,10 @@ bool P4HIR::ArrayElementRefOp::canRewire(const DestructurableMemorySlot &slot,
     if (slot.ptr != getInput()) return false;
 
     // Can only rewire constant indices
-    auto cstIndex = getIndex().getDefiningOp<P4HIR::ConstOp>();
-    if (!cstIndex) return false;
+    unsigned cstIndex;
+    if (!matchPattern(getIndex(), m_ConstantInt(&cstIndex))) return false;
 
-    auto indexAttr = IntegerAttr::get(IndexType::get(getContext()),
-                                      cstIndex.getValueAs<P4HIR::IntAttr>().getUInt());
-
+    auto indexAttr = IntegerAttr::get(IndexType::get(getContext()), cstIndex);
     if (!slot.subelementTypes.contains(indexAttr)) return false;
 
     usedIndices.insert(indexAttr);
@@ -324,10 +323,11 @@ bool P4HIR::ArrayElementRefOp::canRewire(const DestructurableMemorySlot &slot,
 DeletionKind P4HIR::ArrayElementRefOp::rewire(const DestructurableMemorySlot &slot,
                                               DenseMap<Attribute, MemorySlot> &subslots,
                                               OpBuilder &builder, const DataLayout &dataLayout) {
-    auto cstIndex = cast<P4HIR::ConstOp>(getIndex().getDefiningOp());
-    auto indexAttr = IntegerAttr::get(IndexType::get(getContext()),
-                                      cstIndex.getValueAs<P4HIR::IntAttr>().getUInt());
+    unsigned cstIndex;
+    [[maybe_unused]] bool match = matchPattern(getIndex(), m_ConstantInt(&cstIndex));
+    assert(match && "expected constant index");
 
+    auto indexAttr = IntegerAttr::get(IndexType::get(getContext()), cstIndex);
     auto it = subslots.find(indexAttr);
     assert(it != subslots.end());
 

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -1334,8 +1334,8 @@ struct InvertIfCondition : public OpRewritePattern<P4HIR::IfOp> {
         Block *thenBlock = ifOp.thenBlock(), *elseBlock = ifOp.elseBlock();
         if (!thenBlock || !elseBlock) return failure();
 
-        auto condStmt = ifOp.getCondition().getDefiningOp<P4HIR::UnaryOp>();
-        if (!condStmt || condStmt.getKind() != P4HIR::UnaryOpKind::LNot) return failure();
+        auto condStmt = getDefiningUnop(P4HIR::UnaryOpKind::LNot, ifOp.getCondition());
+        if (!condStmt) return failure();
 
         // Swap basic blocks
         auto &thenRegion = ifOp.getThenRegion();


### PR DESCRIPTION
Add matchers for specific constants plus special `m_ZeroInt` zero constant matcher.
Update some code to use constant matchers intead of manual matching.