### PR TITLE
Lower P4HIR bool, unary and cmp to LLVM dialect

### DIFF
--- a/lib/Conversion/P4HIRToLLVM/LowerP4HIRToLLVM.cpp
+++ b/lib/Conversion/P4HIRToLLVM/LowerP4HIRToLLVM.cpp
@@ -99,6 +99,90 @@ struct BinOpConversion : public ConvertOpToLLVMPattern<P4HIR::BinOp> {
     }
 };
 
+struct UnaryOpConversion : public ConvertOpToLLVMPattern<P4HIR::UnaryOp> {
+    using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+    LogicalResult matchAndRewrite(P4HIR::UnaryOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const override {
+        auto input = adaptor.getInput();
+        auto intType = dyn_cast<IntegerType>(input.getType());
+        if (!intType) {
+            return rewriter.notifyMatchFailure(op, "unsupported unary operand type");
+        }
+
+        auto createConstant = [&](int64_t value) {
+            return LLVM::ConstantOp::create(rewriter, op.getLoc(), intType, value);
+        };
+
+        switch (op.getKind()) {
+            case P4HIR::UnaryOpKind::UPlus:
+                rewriter.replaceOp(op, input);
+                return success();
+            case P4HIR::UnaryOpKind::Neg:
+                // LLVM has no integer negation, so `-x` is emitted as `0 - x`.
+                rewriter.replaceOpWithNewOp<LLVM::SubOp>(op, createConstant(0), input);
+                return success();
+            case P4HIR::UnaryOpKind::Cmpl:
+                rewriter.replaceOpWithNewOp<LLVM::XOrOp>(op, input, createConstant(-1));
+                return success();
+            case P4HIR::UnaryOpKind::LNot:
+                if (intType.getWidth() != 1) {
+                    return rewriter.notifyMatchFailure(op, "logical not requires i1 operand");
+                }
+                rewriter.replaceOpWithNewOp<LLVM::XOrOp>(op, input, createConstant(1));
+                return success();
+        }
+        return rewriter.notifyMatchFailure(op, "unsupported unary op kind");
+    }
+};
+
+LogicalResult lowerToICmpOp(P4HIR::CmpOp op, P4HIR::CmpOp::Adaptor adaptor,
+                            ConversionPatternRewriter &rewriter, LLVM::ICmpPredicate predicate) {
+    rewriter.replaceOpWithNewOp<LLVM::ICmpOp>(op, predicate, adaptor.getLhs(), adaptor.getRhs());
+    return success();
+}
+
+struct CmpOpConversion : public ConvertOpToLLVMPattern<P4HIR::CmpOp> {
+    using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+    LogicalResult matchAndRewrite(P4HIR::CmpOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const override {
+        auto lhsType = op.getLhs().getType();
+        if (!isa<P4HIR::BitsType, P4HIR::BoolType>(lhsType)) {
+            return rewriter.notifyMatchFailure(op, "unsupported cmp operand type");
+        }
+
+        bool isSigned = false;  // BoolType lowers to i1 and is always compared as unsigned.
+        if (auto bitsType = dyn_cast<P4HIR::BitsType>(lhsType)) {
+            isSigned = bitsType.isSigned();
+        }
+
+        switch (op.getKind()) {
+            case P4HIR::CmpOpKind::Eq:
+                return lowerToICmpOp(op, adaptor, rewriter, LLVM::ICmpPredicate::eq);
+            case P4HIR::CmpOpKind::Ne:
+                return lowerToICmpOp(op, adaptor, rewriter, LLVM::ICmpPredicate::ne);
+            case P4HIR::CmpOpKind::Lt:
+                return lowerToICmpOp(
+                    op, adaptor, rewriter,
+                    isSigned ? LLVM::ICmpPredicate::slt : LLVM::ICmpPredicate::ult);
+            case P4HIR::CmpOpKind::Le:
+                return lowerToICmpOp(
+                    op, adaptor, rewriter,
+                    isSigned ? LLVM::ICmpPredicate::sle : LLVM::ICmpPredicate::ule);
+            case P4HIR::CmpOpKind::Gt:
+                return lowerToICmpOp(
+                    op, adaptor, rewriter,
+                    isSigned ? LLVM::ICmpPredicate::sgt : LLVM::ICmpPredicate::ugt);
+            case P4HIR::CmpOpKind::Ge:
+                return lowerToICmpOp(
+                    op, adaptor, rewriter,
+                    isSigned ? LLVM::ICmpPredicate::sge : LLVM::ICmpPredicate::uge);
+        }
+        return rewriter.notifyMatchFailure(op, "unsupported cmp op kind");
+    }
+};
+
 struct LowerP4HIRToLLVMPass : public P4::P4MLIR::impl::LowerP4HIRToLLVMBase<LowerP4HIRToLLVMPass> {
     void runOnOperation() override {
         auto &context = getContext();
@@ -131,13 +215,21 @@ void P4::P4MLIR::populateP4HIRToLLVMTypeConversion(LLVMTypeConverter &converter)
         return IntegerType::get(bitsType.getContext(), bitsType.getWidth());
     });
 
+    converter.addConversion(
+        [](P4HIR::BoolType boolType) { return IntegerType::get(boolType.getContext(), 1); });
+
     converter.addTypeAttributeConversion(
         [&converter](P4HIR::BitsType bitsType, P4HIR::IntAttr attr) {
             return IntegerAttr::get(converter.convertType(bitsType), attr.getValue());
+        });
+
+    converter.addTypeAttributeConversion(
+        [&converter](P4HIR::BoolType boolType, P4HIR::BoolAttr attr) {
+            return IntegerAttr::get(converter.convertType(boolType), attr.getValue() ? 1 : 0);
         });
 }
 
 void P4::P4MLIR::populateP4HIRToLLVMConversionPatterns(LLVMTypeConverter &converter,
                                                        RewritePatternSet &patterns) {
-    patterns.add<ConstOpConversion, BinOpConversion>(converter);
+    patterns.add<ConstOpConversion, BinOpConversion, UnaryOpConversion, CmpOpConversion>(converter);
 }

--- a/lib/Conversion/P4HIRToLLVM/LowerP4HIRToLLVM.cpp
+++ b/lib/Conversion/P4HIRToLLVM/LowerP4HIRToLLVM.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "p4mlir/Conversion/P4HIRToLLVM/P4HIRToLLVM.h"
@@ -45,6 +44,28 @@ struct ConstOpConversion : public ConvertOpToLLVMPattern<P4HIR::ConstOp> {
     }
 };
 
+template <typename Op>
+LogicalResult lowerToOp(P4HIR::BinOp op, P4HIR::BinOp::Adaptor adaptor,
+                        ConversionPatternRewriter &rewriter) {
+    rewriter.replaceOpWithNewOp<Op>(op, adaptor.getOperands());
+    return success();
+}
+
+// LLVM integers are signless; signedness comes from the original BitsType.
+template <typename SignedOp, typename UnsignedOp>
+LogicalResult lowerToSignedOrUnsignedOp(P4HIR::BinOp op, P4HIR::BinOp::Adaptor adaptor,
+                                        ConversionPatternRewriter &rewriter) {
+    if (auto bitsType = mlir::dyn_cast<P4HIR::BitsType>(op.getType())) {
+        if (bitsType.isSigned()) {
+            rewriter.replaceOpWithNewOp<SignedOp>(op, adaptor.getOperands());
+        } else {
+            rewriter.replaceOpWithNewOp<UnsignedOp>(op, adaptor.getOperands());
+        }
+        return success();
+    }
+    return rewriter.notifyMatchFailure(op, "expected bits type");
+}
+
 struct BinOpConversion : public ConvertOpToLLVMPattern<P4HIR::BinOp> {
     using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -52,17 +73,29 @@ struct BinOpConversion : public ConvertOpToLLVMPattern<P4HIR::BinOp> {
                                   ConversionPatternRewriter &rewriter) const override {
         switch (op.getKind()) {
             case P4HIR::BinOpKind::Add:
-                rewriter.replaceOpWithNewOp<LLVM::AddOp>(op, adaptor.getOperands());
-                return success();
+                return lowerToOp<LLVM::AddOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::AddSat:
+                return lowerToSignedOrUnsignedOp<LLVM::SAddSat, LLVM::UAddSat>(op, adaptor,
+                                                                               rewriter);
             case P4HIR::BinOpKind::Sub:
-                rewriter.replaceOpWithNewOp<LLVM::SubOp>(op, adaptor.getOperands());
-                return success();
+                return lowerToOp<LLVM::SubOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::SubSat:
+                return lowerToSignedOrUnsignedOp<LLVM::SSubSat, LLVM::USubSat>(op, adaptor,
+                                                                               rewriter);
             case P4HIR::BinOpKind::Mul:
-                rewriter.replaceOpWithNewOp<LLVM::MulOp>(op, adaptor.getOperands());
-                return success();
-            default:
-                return rewriter.notifyMatchFailure(op, "unsupported binop kind");
+                return lowerToOp<LLVM::MulOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::Div:
+                return lowerToSignedOrUnsignedOp<LLVM::SDivOp, LLVM::UDivOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::Mod:
+                return lowerToSignedOrUnsignedOp<LLVM::SRemOp, LLVM::URemOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::And:
+                return lowerToOp<LLVM::AndOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::Or:
+                return lowerToOp<LLVM::OrOp>(op, adaptor, rewriter);
+            case P4HIR::BinOpKind::Xor:
+                return lowerToOp<LLVM::XOrOp>(op, adaptor, rewriter);
         }
+        return rewriter.notifyMatchFailure(op, "unsupported binop kind");
     }
 };
 

--- a/test/Conversion/P4HIRToLLVM/binops.mlir
+++ b/test/Conversion/P4HIRToLLVM/binops.mlir
@@ -26,6 +26,34 @@ module {
   %lhs = p4hir.const #p4hir.int<42> : !u32i
   // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
   %rhs = p4hir.const #p4hir.int<1> : !u32i
+  // CHECK: llvm.intr.uadd.sat(%[[LHS]], %[[RHS]])
+  %sadd = p4hir.binop(sadd, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!s32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !s32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !s32i
+  // CHECK: llvm.intr.sadd.sat(%[[LHS]], %[[RHS]])
+  %sadd = p4hir.binop(sadd, %lhs, %rhs) : !s32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !u32i
   // CHECK: llvm.sub %[[LHS]], %[[RHS]] : i32
   %sub = p4hir.binop(sub, %lhs, %rhs) : !u32i
 }
@@ -40,8 +68,134 @@ module {
   %lhs = p4hir.const #p4hir.int<42> : !u32i
   // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
   %rhs = p4hir.const #p4hir.int<1> : !u32i
+  // CHECK: llvm.intr.usub.sat(%[[LHS]], %[[RHS]])
+  %ssub = p4hir.binop(ssub, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!s32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !s32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !s32i
+  // CHECK: llvm.intr.ssub.sat(%[[LHS]], %[[RHS]])
+  %ssub = p4hir.binop(ssub, %lhs, %rhs) : !s32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !u32i
   // CHECK: llvm.mul %[[LHS]], %[[RHS]] : i32
   %mul = p4hir.binop(mul, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(2 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<2> : !u32i
+  // CHECK: llvm.udiv %[[LHS]], %[[RHS]] : i32
+  %div = p4hir.binop(div, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!s32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !s32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(2 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<2> : !s32i
+  // CHECK: llvm.sdiv %[[LHS]], %[[RHS]] : i32
+  %div = p4hir.binop(div, %lhs, %rhs) : !s32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(2 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<2> : !u32i
+  // CHECK: llvm.urem %[[LHS]], %[[RHS]] : i32
+  %mod = p4hir.binop(mod, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!s32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !s32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(2 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<2> : !s32i
+  // CHECK: llvm.srem %[[LHS]], %[[RHS]] : i32
+  %mod = p4hir.binop(mod, %lhs, %rhs) : !s32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !u32i
+  // CHECK: llvm.and %[[LHS]], %[[RHS]] : i32
+  %and = p4hir.binop(and, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !u32i
+  // CHECK: llvm.or %[[LHS]], %[[RHS]] : i32
+  %or = p4hir.binop(or, %lhs, %rhs) : !u32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[LHS:.*]] = llvm.mlir.constant(42 : i32) : i32
+  %lhs = p4hir.const #p4hir.int<42> : !u32i
+  // CHECK: %[[RHS:.*]] = llvm.mlir.constant(1 : i32) : i32
+  %rhs = p4hir.const #p4hir.int<1> : !u32i
+  // CHECK: llvm.xor %[[LHS]], %[[RHS]] : i32
+  %xor = p4hir.binop(xor, %lhs, %rhs) : !u32i
 }
 
 // -----
@@ -67,21 +221,4 @@ module {
   %prod = p4hir.binop(mul, %sum, %c) : !u32i
   // CHECK: llvm.sub %[[PROD]], %[[D]] : i32
   %res = p4hir.binop(sub, %prod, %d) : !u32i
-}
-
-// -----
-
-// !p4hir.infint has no fixed width and thus no LLVM mapping. Ops using it
-// must be left unconverted rather than crash.
-
-!infint = !p4hir.infint
-
-// CHECK-LABEL: module
-module {
-  // CHECK: p4hir.const
-  %lhs = p4hir.const #p4hir.int<42> : !infint
-  // CHECK: p4hir.const
-  %rhs = p4hir.const #p4hir.int<1> : !infint
-  // CHECK: p4hir.binop(add
-  %add = p4hir.binop(add, %lhs, %rhs) : !infint
 }

--- a/test/Conversion/P4HIRToLLVM/cmp.mlir
+++ b/test/Conversion/P4HIRToLLVM/cmp.mlir
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: p4mlir-opt %s --lower-p4hir-to-llvm -split-input-file | FileCheck %s
+
+// All six kinds on unsigned bit<N> should pick the u* predicates.
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  %a = p4hir.const #p4hir.int<1> : !u32i
+  %b = p4hir.const #p4hir.int<2> : !u32i
+  // CHECK: llvm.icmp "eq"
+  %eq = p4hir.cmp(eq, %a : !u32i, %b : !u32i)
+  // CHECK: llvm.icmp "ne"
+  %ne = p4hir.cmp(ne, %a : !u32i, %b : !u32i)
+  // CHECK: llvm.icmp "ult"
+  %lt = p4hir.cmp(lt, %a : !u32i, %b : !u32i)
+  // CHECK: llvm.icmp "ule"
+  %le = p4hir.cmp(le, %a : !u32i, %b : !u32i)
+  // CHECK: llvm.icmp "ugt"
+  %gt = p4hir.cmp(gt, %a : !u32i, %b : !u32i)
+  // CHECK: llvm.icmp "uge"
+  %ge = p4hir.cmp(ge, %a : !u32i, %b : !u32i)
+}
+
+// -----
+
+// All six kinds on signed int<N> should pick the s* predicates.
+
+!i32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  %a = p4hir.const #p4hir.int<1> : !i32i
+  %b = p4hir.const #p4hir.int<2> : !i32i
+  // CHECK: llvm.icmp "eq"
+  %eq = p4hir.cmp(eq, %a : !i32i, %b : !i32i)
+  // CHECK: llvm.icmp "ne"
+  %ne = p4hir.cmp(ne, %a : !i32i, %b : !i32i)
+  // CHECK: llvm.icmp "slt"
+  %lt = p4hir.cmp(lt, %a : !i32i, %b : !i32i)
+  // CHECK: llvm.icmp "sle"
+  %le = p4hir.cmp(le, %a : !i32i, %b : !i32i)
+  // CHECK: llvm.icmp "sgt"
+  %gt = p4hir.cmp(gt, %a : !i32i, %b : !i32i)
+  // CHECK: llvm.icmp "sge"
+  %ge = p4hir.cmp(ge, %a : !i32i, %b : !i32i)
+}
+
+// -----
+
+// eq/ne on bool operands.
+
+// CHECK-LABEL: module
+module {
+  %a = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  %b = p4hir.const #p4hir.bool<false> : !p4hir.bool
+  // CHECK: llvm.icmp "eq"
+  %eq = p4hir.cmp(eq, %a : !p4hir.bool, %b : !p4hir.bool)
+  // CHECK: llvm.icmp "ne"
+  %ne = p4hir.cmp(ne, %a : !p4hir.bool, %b : !p4hir.bool)
+}

--- a/test/Conversion/P4HIRToLLVM/types.mlir
+++ b/test/Conversion/P4HIRToLLVM/types.mlir
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: p4mlir-opt %s --lower-p4hir-to-llvm -split-input-file | FileCheck %s
+
+// CHECK-LABEL: module
+module {
+  // CHECK: llvm.mlir.constant(true) : i1
+  %t = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  // CHECK: llvm.mlir.constant(false) : i1
+  %f = p4hir.const #p4hir.bool<false> : !p4hir.bool
+}
+
+// -----
+
+!u8i = !p4hir.bit<8>
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: llvm.mlir.constant(42 : i8) : i8
+  %narrow = p4hir.const #p4hir.int<42> : !u8i
+  // CHECK: llvm.mlir.constant(42 : i32) : i32
+  %wide = p4hir.const #p4hir.int<42> : !u32i
+}
+
+// -----
+
+// int<N> lowers to the same signless iN as bit<N>.
+
+!s32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: llvm.mlir.constant(-1 : i32) : i32
+  %neg = p4hir.const #p4hir.int<-1> : !s32i
+}

--- a/test/Conversion/P4HIRToLLVM/unaryops.mlir
+++ b/test/Conversion/P4HIRToLLVM/unaryops.mlir
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: p4mlir-opt %s --lower-p4hir-to-llvm -split-input-file | FileCheck %s
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[X:.*]] = llvm.mlir.constant(5 : i32) : i32
+  %x = p4hir.const #p4hir.int<5> : !u32i
+  // plus is a no-op: no llvm op is inserted; the result reuses %[[X]].
+  // CHECK-NOT: llvm.add
+  // CHECK-NOT: llvm.sub
+  %p = p4hir.unary(plus, %x) : !u32i
+}
+
+// -----
+
+!i32i = !p4hir.int<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[X:.*]] = llvm.mlir.constant(5 : i32) : i32
+  %x = p4hir.const #p4hir.int<5> : !i32i
+  // CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: llvm.sub %[[ZERO]], %[[X]] : i32
+  %n = p4hir.unary(minus, %x) : !i32i
+}
+
+// -----
+
+!u32i = !p4hir.bit<32>
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[X:.*]] = llvm.mlir.constant(5 : i32) : i32
+  %x = p4hir.const #p4hir.int<5> : !u32i
+  // CHECK: %[[ONES:.*]] = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK: llvm.xor %[[X]], %[[ONES]] : i32
+  %c = p4hir.unary(cmpl, %x) : !u32i
+}
+
+// -----
+
+// CHECK-LABEL: module
+module {
+  // CHECK: %[[B:.*]] = llvm.mlir.constant(true) : i1
+  %b = p4hir.const #p4hir.bool<true> : !p4hir.bool
+  // CHECK: %[[ONE:.*]] = llvm.mlir.constant(true) : i1
+  // CHECK: llvm.xor %[[B]], %[[ONE]] : i1
+  %n = p4hir.unary(not, %b) : !p4hir.bool
+}

--- a/test/Conversion/P4HIRToLLVM/unsupported-types.mlir
+++ b/test/Conversion/P4HIRToLLVM/unsupported-types.mlir
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: p4mlir-opt %s --lower-p4hir-to-llvm -split-input-file | FileCheck %s
+
+// !p4hir.infint has no fixed width and thus no LLVM mapping. Ops using it
+// must be left unconverted rather than crash.
+
+!infint = !p4hir.infint
+
+// CHECK-LABEL: module
+module {
+  // CHECK: p4hir.const
+  %lhs = p4hir.const #p4hir.int<42> : !infint
+  // CHECK: p4hir.const
+  %rhs = p4hir.const #p4hir.int<1> : !infint
+  // CHECK: p4hir.binop(add
+  %add = p4hir.binop(add, %lhs, %rhs) : !infint
+}


### PR DESCRIPTION
Stacked on #373, review the last commit only. Will rebase once #373 lands.