### PR TITLE
Implement IndexableType, IndexedField and FieldPath

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/FieldPath.h
+++ b/include/p4mlir/Dialect/P4HIR/FieldPath.h
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2025 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef P4MLIR_DIALECT_P4HIR_P4HIR_FIELDPATH_H
+#define P4MLIR_DIALECT_P4HIR_P4HIR_FIELDPATH_H
+
+#include "p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.h"
+
+namespace P4::P4MLIR::P4HIR {
+
+/// Represents a field path starting from a root type.
+struct FieldPath {
+ private:
+    explicit FieldPath(mlir::Type rootType, mlir::Type leafType, unsigned fieldID)
+        : rootType(rootType), leafType(leafType), fieldID(fieldID) {}
+
+ public:
+    /// Get the max fieldID that reference a field of `type`.
+    static unsigned getMaxFieldID(mlir::Type type);
+
+    /// Get the fieldID for the field at `index` in `itype`.
+    static unsigned getFieldID(P4HIR::IndexableTypeInterface itype, unsigned index);
+
+    /// The results of indexing in an IndexableType using a fieldID.
+    struct IndexingResult {
+        IndexingResult(unsigned index, unsigned parentFieldId, unsigned childFieldId)
+            : index(index), parentFieldId(parentFieldId), childFieldId(childFieldId) {}
+
+        /// The index of the field in the IndexableType type that corresponds to the given fieldID.
+        unsigned index;
+        /// The fieldID for the field at `index`.
+        unsigned parentFieldId;
+        /// The sub-fieldID to index within the resulting field.
+        unsigned childFieldId;
+    };
+
+    /// Find the immidiate field of `itype` that contains the field referenced by `fieldID` and
+    /// return indexing information.
+    static IndexingResult indexInto(P4HIR::IndexableTypeInterface itype, unsigned fieldID);
+
+    /// Create a FieldPath by fully indexing into `rootType` using `fieldID`.
+    static FieldPath fromFieldID(mlir::Type rootType, unsigned fieldID);
+
+    /// Construct a special empty FieldPath.
+    explicit FieldPath() : FieldPath(mlir::Type(), mlir::Type(), 0) {}
+
+    /// Construct a field path representing `rootType`.
+    explicit FieldPath(mlir::Type rootType) : FieldPath(rootType, rootType, 0) {}
+
+    /// Returns true if the given fields paths can be concatenated into a single path with `concat`.
+    static bool canConcat(const FieldPath &lhs, const FieldPath &rhs) {
+        return lhs.isEmpty() || rhs.isEmpty() || lhs.getLeafType() == rhs.getRootType();
+    }
+
+    /// Given two fields paths X->...->Y and Y->...->Z returns X->...->Z.
+    /// Returns FieldPath() if either pah is the special empty path.
+    /// Assumes that `canConcat(lhs, rhs) == true`.
+    static FieldPath concat(const FieldPath &lhs, const FieldPath &rhs);
+
+    /// If this path is of the form X->...->Y->...->Z where Y is the first field for
+    /// which `pred(Y)` is true then return two new field paths X->...->Y and Y->...->Z.
+    /// If pred(X) is true, returns {FieldPath(), *this}
+    /// If there exists no such Y, return {*this, FieldPath()}
+    std::pair<FieldPath, FieldPath> split(llvm::function_ref<bool(FieldPath)> pred) const;
+
+    /// If this is a path X->...->Y and Y is an indexable type with a field Z at `index` make this
+    /// path represent X->...->Y->Z.
+    FieldPath &append(unsigned index);
+
+    FieldPath operator[](unsigned index) {
+        FieldPath res = *this;
+        res.append(index);
+        return res;
+    }
+
+    /// Return true is this is the special empty path.
+    bool isEmpty() const { return *this == FieldPath(); }
+
+    mlir::Type getRootType() const { return rootType; }
+    mlir::Type getLeafType() const { return leafType; }
+
+    /// Return a unique ID for the referenced field within the root type.
+    unsigned getFieldID() const { return fieldID; }
+
+    // Get an identified for the the full path.
+    std::string getIdentifier() const;
+
+    bool operator==(const FieldPath &rhs) const {
+        return getRootType() == rhs.getRootType() && getLeafType() == rhs.getLeafType() &&
+               getFieldID() == rhs.getFieldID();
+    }
+
+    bool operator!=(const FieldPath &rhs) const { return !operator==(rhs); }
+
+    /// Helper function to iterate all prefix FieldPaths from root down to leaf.
+    /// Returning false from `cb` will stop the iteration.
+    bool forEach(llvm::function_ref<bool(FieldPath)> cb) const;
+
+    /// Helper function to iterate all IndexedFields from root down to leaf.
+    /// Returning false from `cb` will stop the iteration.
+    bool forEachField(llvm::function_ref<bool(IndexedField)> cb) const;
+
+    void print(llvm::raw_ostream &os) const;
+
+    struct DenseMapInfo {
+        static inline FieldPath getEmptyKey() {
+            FieldPath specialEmpty(mlir::Type(), mlir::Type(),
+                                   std::numeric_limits<unsigned>::max());
+            return specialEmpty;
+        }
+
+        static inline FieldPath getTombstoneKey() {
+            FieldPath specialTombstone(mlir::Type(), mlir::Type(),
+                                       std::numeric_limits<unsigned>::max() - 1);
+            return specialTombstone;
+        }
+
+        static unsigned getHashValue(const FieldPath &path) {
+            return llvm::hash_combine(path.getRootType(), path.getLeafType(), path.getFieldID());
+        }
+
+        static bool isEqual(const FieldPath &lhs, const FieldPath &rhs) { return lhs == rhs; }
+    };
+
+ private:
+    /// The root type that we're indexing into.
+    mlir::Type rootType;
+    /// Cached type of the referenced field.
+    mlir::Type leafType;
+    /// FieldID is a unique DFS-based ID of the referenced field within `rootType`. For example:
+    /// ```
+    /// struct a  /* 0 */ {
+    ///   int b; /* 1 */
+    ///   struct c /* 2 */ {
+    ///     int d; /* 3 */
+    ///   }
+    /// }
+    /// ```
+    unsigned fieldID;
+};
+
+}  // namespace P4::P4MLIR::P4HIR
+
+#endif  // P4MLIR_DIALECT_P4HIR_P4HIR_FIELDPATH_H

--- a/include/p4mlir/Dialect/P4HIR/FieldPath.h
+++ b/include/p4mlir/Dialect/P4HIR/FieldPath.h
@@ -9,15 +9,79 @@
 
 namespace P4::P4MLIR::P4HIR {
 
-/// Represents a field path starting from a root type.
-struct FieldPath {
+using FieldWithID = std::pair<IndexedField, unsigned>;
+
+/// This struct provides various utilities for performing operations related to FieldIDs.
+/// A FieldID is a unique DFS-based ID of a field nested somewhere within an indexable-type.
+/// For example:
+/// ```
+/// struct a  /* 0 */ {
+///   int b; /* 1 */
+///   struct c /* 2 */ {
+///     int d; /* 3 */
+///   }
+/// }
+/// ```
+struct FieldIDs {
  private:
-    explicit FieldPath(mlir::Type rootType, mlir::Type leafType, unsigned fieldID)
-        : rootType(rootType), leafType(leafType), fieldID(fieldID) {}
+    static unsigned getNextFieldID(unsigned currentFieldID, P4HIR::IndexableTypeInterface itype,
+                                   unsigned index) {
+        return currentFieldID + 1 + getMaxFieldID(itype.getFieldType(index));
+    }
+
+    /// An iterator type to iterate fields together with their fieldIDs.
+    struct FieldWithIDIterator
+        : public llvm::iterator_facade_base<FieldWithIDIterator, std::forward_iterator_tag,
+                                            FieldWithID> {
+        FieldWithIDIterator(P4HIR::IndexableTypeInterface type, unsigned index, unsigned fieldID)
+            : type(type), index(index), fieldID(fieldID) {}
+
+        FieldWithID operator*() const { return {type.getField(index), fieldID}; }
+
+        bool operator==(const FieldWithIDIterator &other) const {
+            assert((type == other.type) && "Invariant");
+            return index == other.index;
+        }
+
+        using llvm::iterator_facade_base<FieldWithIDIterator, std::forward_iterator_tag,
+                                         FieldWithID>::operator++;
+
+        void operator++() {
+            fieldID = getNextFieldID(fieldID, type, index);
+            index++;
+        }
+
+     private:
+        P4HIR::IndexableTypeInterface type;
+        unsigned index;
+        unsigned fieldID;
+    };
 
  public:
-    /// Get the max fieldID that reference a field of `type`.
-    static unsigned getMaxFieldID(mlir::Type type);
+    /// Return a range to iterate the fields in `itype` paired with their fieldIDs.
+    static mlir::iterator_range<FieldWithIDIterator> getFieldsWithIDs(
+        P4HIR::IndexableTypeInterface itype) {
+        return {FieldWithIDIterator(itype, 0, 1),
+                FieldWithIDIterator(itype, itype.getFieldCount(), 0)};
+    }
+
+    /// Get the max fieldID that can reference a field of `type`.
+    static unsigned getMaxFieldID(mlir::Type type) {
+        if (auto itype = mlir::dyn_cast<P4HIR::IndexableTypeInterface>(type))
+            return itype.getNestedFieldCount();
+
+        return 0;
+    }
+
+    /// Return true if `fieldID` is within the valid range for `type`.
+    static bool isValid(mlir::Type type, unsigned fieldID) {
+        return fieldID <= getMaxFieldID(type);
+    }
+
+    /// Return true if `fieldID` is within the valid range for to represent a field of `type`.
+    static bool isValidField(mlir::Type type, unsigned fieldID) {
+        return fieldID > 0 && fieldID <= getMaxFieldID(type);
+    }
 
     /// Get the fieldID for the field at `index` in `itype`.
     static unsigned getFieldID(P4HIR::IndexableTypeInterface itype, unsigned index);
@@ -38,70 +102,191 @@ struct FieldPath {
     /// Find the immediate field of `itype` that contains the field referenced by `fieldID` and
     /// return indexing information.
     static IndexingResult indexInto(P4HIR::IndexableTypeInterface itype, unsigned fieldID);
+};
 
-    /// Create a FieldPath by fully indexing into `rootType` using `fieldID`.
-    static FieldPath fromFieldID(mlir::Type rootType, unsigned fieldID);
+/// Represents a field path starting from a root type.
+struct FieldPath {
+ private:
+    explicit FieldPath(mlir::Type rootType, mlir::Type leafType, unsigned fieldID)
+        : rootType(rootType), leafType(leafType), fieldID(fieldID) {}
 
+ public:
     /// Construct a special empty FieldPath.
     explicit FieldPath() : FieldPath(mlir::Type(), mlir::Type(), 0) {}
 
     /// Construct a field path representing `rootType`.
     explicit FieldPath(mlir::Type rootType) : FieldPath(rootType, rootType, 0) {}
 
+    /// Construct a field path from a IndexedField. Allow implicit construction.
+    FieldPath(P4HIR::IndexedField field) : FieldPath(field.getParentType()) {
+        append(field.getIndex());
+    }
+
+    /// Create a FieldPath by fully indexing into `rootType` using `fieldID`.
+    static FieldPath fromFieldID(mlir::Type rootType, unsigned fieldID);
+
+    /// Perform a preorder DFS traversal on all fields nested in `type` and call `cb`.
+    static void forEachFieldPath(mlir::Type type, llvm::function_ref<void(FieldPath)> cb);
+
     /// Returns true if the given fields paths can be concatenated into a single path with `concat`.
-    static bool canConcat(const FieldPath &lhs, const FieldPath &rhs) {
-        return lhs.isEmpty() || rhs.isEmpty() || lhs.getLeafType() == rhs.getRootType();
+    static bool canConcat(FieldPath lhs, FieldPath rhs) {
+        return lhs.isEmpty() || rhs.isEmpty() || lhs.getType() == rhs.getRootType();
     }
 
     /// Given two fields paths X->...->Y and Y->...->Z returns X->...->Z.
     /// Returns FieldPath() if either pah is the special empty path.
     /// Assumes that `canConcat(lhs, rhs) == true`.
-    static FieldPath concat(const FieldPath &lhs, const FieldPath &rhs);
+    static FieldPath concat(FieldPath lhs, FieldPath rhs) { return lhs.concat(rhs); }
 
-    /// If this path is of the form X->...->Y->...->Z where Y is the first field for
+    /// If this is a path X->...->Y and `rhs` is another path Y->...->Z returns X->...->Z.
+    /// Returns FieldPath() if either pah is the special empty path.
+    /// Assumes that `canConcat(lhs, rhs) == true`.
+    FieldPath &concat(FieldPath rhs);
+
+    /// If this path is of the form X->...->Y->...->Z where Y is the first prefix path for
     /// which `pred(Y)` is true then return two new field paths X->...->Y and Y->...->Z.
     /// If pred(X) is true, returns {FieldPath(), *this}
     /// If there exists no such Y, return {*this, FieldPath()}
     std::pair<FieldPath, FieldPath> split(llvm::function_ref<bool(FieldPath)> pred) const;
 
     /// If this is a path X->...->Y and Y is an indexable type with a field Z at `index` make this
-    /// path represent X->...->Y->Z.
-    FieldPath &append(unsigned index);
+    /// path represent X->...->Y->Z and return true. Otherwise return false;
+    bool try_append(unsigned index);
 
-    FieldPath operator[](unsigned index) {
+    bool try_append(P4HIR::IndexedField field) {
+        assert((getType() == field.getParentType()) && "Incorrect indexed field");
+        return try_append(field.getIndex());
+    }
+
+    /// If this is a path X->...->Y and Y is a struct-like type with a field Z named `name` make
+    /// this path represent X->...->Y->Z and return true. Otherwise return false;
+    bool try_append(llvm::StringRef name);
+
+    FieldPath &append(unsigned index) {
+        [[maybe_unused]] bool success = try_append(index);
+        assert(success && "Missing field");
+        return *this;
+    }
+
+    FieldPath &append(P4HIR::IndexedField field) {
+        assert((getType() == field.getParentType()) && "Incorrect indexed field");
+        return append(field.getIndex());
+    }
+
+    FieldPath &append(llvm::StringRef name) {
+        [[maybe_unused]] bool success = try_append(name);
+        assert(success && "Missing field");
+        return *this;
+    }
+
+    template <typename T>
+    FieldPath operator[](T &&arg) const {
         FieldPath res = *this;
-        res.append(index);
+        res.append(std::forward<T>(arg));
         return res;
     }
 
     /// Return true is this is the special empty path.
     bool isEmpty() const { return *this == FieldPath(); }
+    explicit operator bool() const { return !isEmpty(); }
 
+    /// Return the root type of this path.
     mlir::Type getRootType() const { return rootType; }
-    mlir::Type getLeafType() const { return leafType; }
+
+    /// Return the leaf type of this path.
+    mlir::Type getType() const { return leafType; }
 
     /// Return a unique ID for the referenced field within the root type.
     unsigned getFieldID() const { return fieldID; }
 
     // Get an identified for the the full path.
-    std::string getIdentifier() const;
+    std::string getIdentifier(llvm::StringRef delimiter = ".") const;
 
     bool operator==(const FieldPath &rhs) const {
-        return getRootType() == rhs.getRootType() && getLeafType() == rhs.getLeafType() &&
+        return getRootType() == rhs.getRootType() && getType() == rhs.getType() &&
                getFieldID() == rhs.getFieldID();
     }
 
     bool operator!=(const FieldPath &rhs) const { return !operator==(rhs); }
 
-    /// Helper function to iterate all prefix FieldPaths from root down to leaf.
-    /// Returning false from `cb` will stop the iteration.
-    bool forEach(llvm::function_ref<bool(FieldPath)> cb) const;
+ private:
+    // A flexible iterator type to iterate parts of a fieldID access in a type.
+    using PathIteratorData = std::tuple<mlir::Type, mlir::Type, unsigned, unsigned, unsigned>;
+    struct PathIterator : public llvm::iterator_facade_base<PathIterator, std::forward_iterator_tag,
+                                                            PathIteratorData> {
+        PathIterator(mlir::Type type, unsigned fieldID)
+            : parentType(type), type(type), index(0), lhsFid(0), rhsFid(fieldID) {}
 
-    /// Helper function to iterate all IndexedFields from root down to leaf.
-    /// Returning false from `cb` will stop the iteration.
-    bool forEachField(llvm::function_ref<bool(IndexedField)> cb) const;
+        static PathIterator end() { return PathIterator(mlir::Type(), 0); }
+
+        PathIteratorData operator*() const { return {parentType, type, index, lhsFid, rhsFid}; }
+
+        bool operator==(const PathIterator &other) const {
+            return type == other.type && lhsFid == other.lhsFid && rhsFid == other.rhsFid;
+        }
+
+        using llvm::iterator_facade_base<PathIterator, std::forward_iterator_tag,
+                                         PathIteratorData>::operator++;
+
+        void operator++() {
+            if (rhsFid == 0) {
+                // Advance to special end iterator state.
+                *this = end();
+                return;
+            }
+
+            auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
+            auto indexingResult = FieldIDs::indexInto(itype, rhsFid);
+            parentType = type;
+            type = itype.getFieldType(indexingResult.index);
+            index = indexingResult.index;
+            lhsFid += indexingResult.parentFieldId;
+            rhsFid = indexingResult.childFieldId;
+        }
+
+     private:
+        mlir::Type parentType;
+        mlir::Type type;
+        unsigned index;
+        unsigned lhsFid;
+        unsigned rhsFid;
+    };
+
+    PathIterator begin() const { return PathIterator(getRootType(), getFieldID()); }
+    PathIterator end() const { return PathIterator::end(); }
+
+ public:
+    /// Iterate all prefix paths that make up this path.
+    /// For a path T.x.y.z this will yield T, T.x, T.x.y and T.x.y.z.
+    auto iterPaths() const {
+        mlir::iterator_range<PathIterator> range = {begin(), end()};
+        return llvm::map_range(range, [&](auto info) {
+            auto [parentType, type, index, lhsFid, rhsFid] = info;
+            return FieldPath(getRootType(), type, lhsFid);
+        });
+    }
+
+    /// Iterate all fields that make up this path.
+    /// For a path T.x.y.z this will yield .x, .y and .z.
+    auto iterFields() const {
+        mlir::iterator_range<PathIterator> range = {std::next(begin()), end()};
+        return llvm::map_range(range, [&](auto info) {
+            auto [parentType, type, index, lhsFid, rhsFid] = info;
+            return IndexedField(parentType, index);
+        });
+    }
+
+    /// Create a new path by appending the field indices of this path on top of `newRootType`.
+    FieldPath withRoot(mlir::Type newRootType) const;
 
     void print(llvm::raw_ostream &os) const;
+
+    std::string str() const {
+        std::string buffer;
+        llvm::raw_string_ostream ss(buffer);
+        print(ss);
+        return buffer;
+    }
 
     struct DenseMapInfo {
         static inline FieldPath getEmptyKey() {
@@ -117,7 +302,7 @@ struct FieldPath {
         }
 
         static unsigned getHashValue(const FieldPath &path) {
-            return llvm::hash_combine(path.getRootType(), path.getLeafType(), path.getFieldID());
+            return llvm::hash_combine(path.getRootType(), path.getType(), path.getFieldID());
         }
 
         static bool isEqual(const FieldPath &lhs, const FieldPath &rhs) { return lhs == rhs; }
@@ -128,17 +313,14 @@ struct FieldPath {
     mlir::Type rootType;
     /// Cached type of the referenced field.
     mlir::Type leafType;
-    /// FieldID is a unique DFS-based ID of the referenced field within `rootType`. For example:
-    /// ```
-    /// struct a  /* 0 */ {
-    ///   int b; /* 1 */
-    ///   struct c /* 2 */ {
-    ///     int d; /* 3 */
-    ///   }
-    /// }
-    /// ```
+    /// The fieldID that indexes into `rootType`.
     unsigned fieldID;
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const FieldPath &path) {
+    path.print(os);
+    return os;
+}
 
 }  // namespace P4::P4MLIR::P4HIR
 

--- a/include/p4mlir/Dialect/P4HIR/FieldPath.h
+++ b/include/p4mlir/Dialect/P4HIR/FieldPath.h
@@ -258,7 +258,7 @@ struct FieldPath {
  public:
     /// Iterate all prefix paths that make up this path.
     /// For a path T.x.y.z this will yield T, T.x, T.x.y and T.x.y.z.
-    auto iterPaths() const {
+    auto paths() const {
         mlir::iterator_range<PathIterator> range = {begin(), end()};
         return llvm::map_range(range, [&](auto info) {
             auto [parentType, type, index, lhsFid, rhsFid] = info;
@@ -268,12 +268,16 @@ struct FieldPath {
 
     /// Iterate all fields that make up this path.
     /// For a path T.x.y.z this will yield .x, .y and .z.
-    auto iterFields() const {
+    auto fields() const {
         mlir::iterator_range<PathIterator> range = {std::next(begin()), end()};
         return llvm::map_range(range, [&](auto info) {
             auto [parentType, type, index, lhsFid, rhsFid] = info;
             return IndexedField(parentType, index);
         });
+    }
+
+    auto field_indices() const {
+        return llvm::map_range(fields(), [](auto field) { return field.getIndex(); });
     }
 
     /// Create a new path by appending the field indices of this path on top of `newRootType`.

--- a/include/p4mlir/Dialect/P4HIR/FieldPath.h
+++ b/include/p4mlir/Dialect/P4HIR/FieldPath.h
@@ -35,7 +35,7 @@ struct FieldPath {
         unsigned childFieldId;
     };
 
-    /// Find the immidiate field of `itype` that contains the field referenced by `fieldID` and
+    /// Find the immediate field of `itype` that contains the field referenced by `fieldID` and
     /// return indexing information.
     static IndexingResult indexInto(P4HIR::IndexableTypeInterface itype, unsigned fieldID);
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1153,7 +1153,14 @@ def StructExtractOp : P4HIR_Op<"struct_extract",
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$input, "P4HIR::IndexedField":$field)>,
-    OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName)>,
+    OpBuilder<(ins "mlir::Value":$input, "unsigned":$fieldIndex), [{
+      auto structLikeType = mlir::cast<P4HIR::StructLikeTypeInterface>(input.getType());
+      build($_builder, $_state, input, structLikeType.getField(fieldIndex));
+    }]>,
+    OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName), [{
+      auto structLikeType = mlir::cast<P4HIR::StructLikeTypeInterface>(input.getType());
+      build($_builder, $_state, input, *structLikeType.getFieldByName(fieldName));
+    }]>,
     OpBuilder<(ins "mlir::Value":$input, "llvm::StringRef":$fieldName), [{
       build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
     }]>
@@ -1197,7 +1204,14 @@ def StructFieldRefOp : P4HIR_Op<"struct_field_ref",
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$input, "P4HIR::IndexedField":$field)>,
-    OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName)>,
+    OpBuilder<(ins "mlir::Value":$input, "unsigned":$fieldIndex), [{
+      auto structLikeType = P4HIR::unref<P4HIR::StructLikeTypeInterface>(input.getType());
+      build($_builder, $_state, input, structLikeType.getField(fieldIndex));
+    }]>,
+    OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName), [{
+      auto structLikeType = P4HIR::unref<P4HIR::StructLikeTypeInterface>(input.getType());
+      build($_builder, $_state, input, *structLikeType.getFieldByName(fieldName));
+    }]>,
     OpBuilder<(ins "mlir::Value":$input, "llvm::StringRef":$fieldName), [{
       build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
     }]>

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -1152,7 +1152,7 @@ def StructExtractOp : P4HIR_Op<"struct_extract",
   let hasCanonicalizeMethod = 1;
 
   let builders = [
-    OpBuilder<(ins "mlir::Value":$input, "P4HIR::FieldInfo":$field)>,
+    OpBuilder<(ins "mlir::Value":$input, "P4HIR::IndexedField":$field)>,
     OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName)>,
     OpBuilder<(ins "mlir::Value":$input, "llvm::StringRef":$fieldName), [{
       build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
@@ -1163,7 +1163,7 @@ def StructExtractOp : P4HIR_Op<"struct_extract",
     /// Return the name attribute of the accessed field.
     mlir::StringAttr getFieldNameAttr() {
       auto type = mlir::cast<P4HIR::StructLikeTypeInterface>(getInput().getType());
-      return type.getFields()[getFieldIndex()].name;
+      return type.getField(getFieldIndex()).getNameAttr();
     }
 
     /// Return the name of the accessed field.
@@ -1196,7 +1196,7 @@ def StructFieldRefOp : P4HIR_Op<"struct_field_ref",
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "mlir::Value":$input, "P4HIR::FieldInfo":$field)>,
+    OpBuilder<(ins "mlir::Value":$input, "P4HIR::IndexedField":$field)>,
     OpBuilder<(ins "mlir::Value":$input, "mlir::StringAttr":$fieldName)>,
     OpBuilder<(ins "mlir::Value":$input, "llvm::StringRef":$fieldName), [{
       build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
@@ -1207,7 +1207,7 @@ def StructFieldRefOp : P4HIR_Op<"struct_field_ref",
     /// Return the name attribute of the accessed field.
     mlir::StringAttr getFieldNameAttr() {
       auto type = mlir::cast<StructLikeTypeInterface>(mlir::cast<ReferenceType>(getInput().getType()).getObjectType());
-      return type.getFields()[getFieldIndex()].name;
+      return type.getField(getFieldIndex()).getNameAttr();
     }
 
     /// Return the name of the accessed field.

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.h
@@ -5,41 +5,50 @@
 #ifndef P4MLIR_DIALECT_P4HIR_P4HIR_TYPEINTERFACES_H
 #define P4MLIR_DIALECT_P4HIR_P4HIR_TYPEINTERFACES_H
 
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
 
 namespace P4::P4MLIR::P4HIR {
 
-/// Struct defining a field. Used in structs and header
+/// Struct that represents a particular field of an IndexableType.
+struct IndexedField {
+    IndexedField(mlir::Type indexableType, unsigned index)
+        : indexableType(indexableType), index(index) {}
+    unsigned getIndex() const { return index; }
+    mlir::Type getParentType() const { return indexableType; }
+    mlir::Type getType() const;
+    std::string getName() const;
+    mlir::StringAttr getNameAttr() const;
+    mlir::DictionaryAttr getAnnotations() const;
+
+    bool operator==(const IndexedField &o) const {
+        return indexableType == o.indexableType && index == o.index;
+    }
+    bool operator!=(const IndexedField &o) const { return !operator==(o); }
+
+ private:
+    mlir::Type indexableType;
+    unsigned index;
+};
+
+/// Struct field definition. Used to define structs and headers
 struct FieldInfo {
+    FieldInfo(mlir::StringAttr name, mlir::Type type, mlir::DictionaryAttr annotations = {})
+        : name(name),
+          type(type),
+          annotations(annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr()) {}
+
+    mlir::Type getType() const { return type; }
+    std::string getName() const { return name.getValue().str(); }
+    mlir::StringAttr getNameAttr() const { return name; }
+    mlir::DictionaryAttr getAnnotations() const { return annotations; }
+
     mlir::StringAttr name;
     mlir::Type type;
     mlir::DictionaryAttr annotations;
-
-  FieldInfo(mlir::StringAttr name,
-            mlir::Type type,
-            mlir::DictionaryAttr annotations = {})
-    : name(name), type(type),
-      annotations(annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr())
-  { }
 };
 
-namespace FieldIdImpl {
-unsigned getMaxFieldID(::mlir::Type);
-
-std::pair<::mlir::Type, unsigned> getSubTypeByFieldID(::mlir::Type, unsigned fieldID);
-
-::mlir::Type getFinalTypeByFieldID(::mlir::Type type, unsigned fieldID);
-
-std::pair<unsigned, bool> projectToChildFieldID(::mlir::Type, unsigned fieldID, unsigned index);
-
-std::pair<unsigned, unsigned> getIndexAndSubfieldID(::mlir::Type type, unsigned fieldID);
-
-unsigned getFieldID(::mlir::Type type, unsigned index);
-
-unsigned getIndexForFieldID(::mlir::Type type, unsigned fieldID);
-
-}  // namespace FieldIdImpl
 }  // namespace P4::P4MLIR::P4HIR
 
 // We explicitly do not use push / pop for diagnostic in

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.td
@@ -7,73 +7,70 @@
 
 include "mlir/IR/OpBase.td"
 
-def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
+def IndexableTypeInterface : TypeInterface<"IndexableTypeInterface"> {
   let description = [{
-    Common methods for types which can be indexed by a FieldID.
-    FieldID is a depth-first numbering of the elements of a type.  For example:
-    ```
-    struct a  /* 0 */ {
-      int b; /* 1 */
-      struct c /* 2 */ {
-        int d; /* 3 */
-      }
-    }
-
-    int e; /* 0 */
-    ```
+    Interface for a type that consists of fields that can be indexed.
   }];
 
   let methods = [
-    InterfaceMethod<"Get the maximum field ID for this type",
-      "unsigned", "getMaxFieldID">,
+    InterfaceMethod<[{
+      Get the number of fields that this type has.
+    }],
+      "unsigned", "getFieldCount", (ins)>,
 
     InterfaceMethod<[{
-      Get the sub-type of a type for a field ID, and the subfield's ID. Strip
-      off a single layer of this type and return the sub-type and a field ID
-      targeting the same field, but rebased on the sub-type.
-
-      The resultant type *may* not be a FieldIDTypeInterface if the resulting 
-      fieldID is zero.  This means that leaf types may be ground without 
-      implementing an interface.  An empty aggregate will also appear as a 
-      zero.
+      Get the type for the field at a specific index.
     }],
-      "std::pair<::mlir::Type, unsigned>", "getSubTypeByFieldID", (ins "unsigned":$fieldID)>,
+      "mlir::Type", "getFieldType", (ins "unsigned":$index)>,
 
     InterfaceMethod<[{
-      Returns the effective field id when treating the index field as the
-      root of the type.  Essentially maps a fieldID to a fieldID after a
-      subfield op. Returns the new id and whether the id is in the given
-      child.
+      Get the name for the field at a specific index.
     }],
-      "std::pair<unsigned, bool>", "projectToChildFieldID", (ins "unsigned":$fieldID, "unsigned":$index)>,
+      "std::string", "getFieldName", (ins "unsigned":$index)>,
 
     InterfaceMethod<[{
-      Returns the index (e.g. struct or vector element) for a given FieldID.
-      This returns the containing index in the case that the fieldID points to a
-      child field of a field.
+      Get the name for the field at a specific index as a StringAttr.
+      Override to provide more optimized access for cases where the indexable type
+      already has a StringAttr for field names.
     }],
-      "unsigned", "getIndexForFieldID", (ins "unsigned":$fieldID)>,
-
+      "mlir::StringAttr", "getFieldNameAttr", (ins "unsigned":$index),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        return mlir::StringAttr::get($_type.getContext(), $_type.getFieldName(index));
+      }]>,
+  
     InterfaceMethod<[{
-      Return the fieldID of a given index (e.g. struct or vector element).
-      Field IDs start at 1, and are assigned
-      to each field in a recursive depth-first walk of all
-      elements. A field ID of 0 is used to reference the type itself.
+      Get additional annotations for the field at a specific index.
     }],
-      "unsigned", "getFieldID", (ins "unsigned":$index)>,
-
-    InterfaceMethod<[{
-      Find the index of the element that contains the given fieldID.
-      As well, rebase the fieldID to the element.
-    }],
-      "std::pair<unsigned, unsigned>", "getIndexAndSubfieldID", (ins "unsigned":$fieldID)>,
-
+      "mlir::DictionaryAttr", "getFieldAnnotations", (ins "unsigned":$index),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        return {};
+      }]>,
   ];
+
+  let extraClassDeclaration = [{
+    IndexedField getField(unsigned idx) {
+      return P4HIR::IndexedField(*this, idx);
+    }
+
+    auto getFields() {
+      return llvm::map_range(llvm::seq(0u, getFieldCount()), [this](unsigned idx) {
+        return getField(idx);
+      });
+    }
+
+    auto getFieldTypes() {
+      return llvm::map_range(llvm::seq(0u, getFieldCount()), [this](unsigned idx) {
+        return getField(idx).getType();
+      });
+    }
+  }];
 
   let cppNamespace = "::P4::P4MLIR::P4HIR";
 }
 
-def StructLikeTypeInterface : TypeInterface<"StructLikeTypeInterface", [FieldIDTypeInterface]> {
+def StructLikeTypeInterface : TypeInterface<"StructLikeTypeInterface", [IndexableTypeInterface]> {
   let description = [{
     Common methods for struct-like types that could be viewed as a collection
     of named fields
@@ -81,33 +78,17 @@ def StructLikeTypeInterface : TypeInterface<"StructLikeTypeInterface", [FieldIDT
 
   let methods = [
     InterfaceMethod<[{
-      Get the type of the field at a given index
+      Access the array of struct field info.
     }],
-      "mlir::Type", "getFieldType", (ins "mlir::StringRef":$fieldName)>,
-   InterfaceMethod<[{
-      Get the field index given the name in StringRef
-    }],
-     "std::optional<unsigned>", "getFieldIndex", (ins "mlir::StringRef":$fieldName)>,
+      "llvm::ArrayRef<FieldInfo>", "getElements", (ins)>,
+
    InterfaceMethod<[{
       Get the field given the name in StringRef
     }],
-     "std::optional<FieldInfo>", "getField", (ins "mlir::StringRef":$fieldName)>,
-   InterfaceMethod<[{
-      Get all the fields.
-    }],
-     "llvm::ArrayRef<FieldInfo>", "getFields">,
-   InterfaceMethod<[{
-      Get all types of the fields.
-    }],
-     "void", "getInnerTypes", (ins "mlir::SmallVectorImpl<mlir::Type> &":$types)>,
-   InterfaceMethod<[{
-      Get the field given the ID.
-    }],
-     "FieldInfo", "getFieldByID", (ins "unsigned":$fieldID)>,
+     "std::optional<IndexedField>", "getFieldByName", (ins "mlir::StringRef":$fieldName)>,
   ];
   let cppNamespace = "::P4::P4MLIR::P4HIR";
 }
-
 
 def AnnotatedType : TypeInterface<"AnnotatedType"> {
   let description = [{

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.td
@@ -24,12 +24,12 @@ def IndexableTypeInterface : TypeInterface<"IndexableTypeInterface"> {
       "mlir::Type", "getFieldType", (ins "unsigned":$index)>,
 
     InterfaceMethod<[{
-      Get the name for the field at a specific index.
+      Get a name for the field at a specific index.
     }],
       "std::string", "getFieldName", (ins "unsigned":$index)>,
 
     InterfaceMethod<[{
-      Get the name for the field at a specific index as a StringAttr.
+      Get a name for the field at a specific index as a StringAttr.
       Override to provide more optimized access for cases where the indexable type
       already has a StringAttr for field names.
     }],
@@ -47,20 +47,40 @@ def IndexableTypeInterface : TypeInterface<"IndexableTypeInterface"> {
       /*defaultImpl=*/ [{
         return {};
       }]>,
+
+    InterfaceMethod<[{
+      Get the number of fields recursively nested under this type.
+    }],
+      "unsigned", "getNestedFieldCount", (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        unsigned nestedFieldCount = 0;
+
+        for (auto field : $_type.getFields()) {
+          // Count this field.
+          nestedFieldCount += 1;
+
+          // If this field is also indexable, count all nested sub-fields.
+          auto itype = mlir::dyn_cast<P4::P4MLIR::P4HIR::IndexableTypeInterface>(field.getType());
+          if (itype) nestedFieldCount += itype.getNestedFieldCount();
+        }
+
+        return nestedFieldCount;
+      }]>,
   ];
 
   let extraClassDeclaration = [{
-    IndexedField getField(unsigned idx) {
-      return P4HIR::IndexedField(*this, idx);
+    auto getField(unsigned idx) const {
+      return P4::P4MLIR::P4HIR::IndexedField(*this, idx);
     }
 
-    auto getFields() {
+    auto getFields() const {
       return llvm::map_range(llvm::seq(0u, getFieldCount()), [this](unsigned idx) {
         return getField(idx);
       });
     }
 
-    auto getFieldTypes() {
+    auto getFieldTypes() const {
       return llvm::map_range(llvm::seq(0u, getFieldCount()), [this](unsigned idx) {
         return getField(idx).getType();
       });
@@ -85,7 +105,7 @@ def StructLikeTypeInterface : TypeInterface<"StructLikeTypeInterface", [Indexabl
    InterfaceMethod<[{
       Get the field given the name in StringRef
     }],
-     "std::optional<IndexedField>", "getFieldByName", (ins "mlir::StringRef":$fieldName)>,
+     "std::optional<P4::P4MLIR::P4HIR::IndexedField>", "getFieldByName", (ins "mlir::StringRef":$fieldName)>,
   ];
   let cppNamespace = "::P4::P4MLIR::P4HIR";
 }

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.h
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.h
@@ -16,6 +16,7 @@
 #include "p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.h"
 
 namespace P4::P4MLIR::P4HIR {
+
 mlir::TypedAttr getStructLikeDefaultValue(StructLikeTypeInterface type);
 
 void printFieldInfo(mlir::AsmPrinter &p, const FieldInfo &fi);
@@ -34,5 +35,22 @@ void printFields(mlir::AsmPrinter &p, llvm::StringRef name, llvm::ArrayRef<Field
 
 #define GET_TYPEDEF_CLASSES
 #include "p4mlir/Dialect/P4HIR/P4HIR_Types.h.inc"
+
+namespace P4::P4MLIR::P4HIR {
+
+template <typename TypeT = mlir::Type>
+inline TypeT maybeUnref(mlir::Type type) {
+    if (auto refType = mlir::dyn_cast<P4::P4MLIR::P4HIR::ReferenceType>(type))
+        type = refType.getObjectType();
+    return mlir::dyn_cast<TypeT>(type);
+}
+
+template <typename TypeT = mlir::Type>
+inline TypeT unref(mlir::Type type) {
+    auto refType = mlir::cast<P4::P4MLIR::P4HIR::ReferenceType>(type);
+    return mlir::dyn_cast<TypeT>(refType.getObjectType());
+}
+
+}  // namespace P4::P4MLIR::P4HIR
 
 #endif  // P4MLIR_DIALECT_P4HIR_P4HIR_TYPES_H

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -434,7 +434,7 @@ class StructLikeType<string name, string typeMnemonic>
 
     std::optional<P4HIR::IndexedField> getFieldByName(mlir::StringRef fieldName) {
       for (auto field : getFields())
-        if (field.getName() == fieldName) return field;
+        if (field.getNameAttr() == fieldName) return field;
       return {};
     }
 

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -398,6 +398,7 @@ class StructLikeType<string name, string typeMnemonic>
   let parameters = (
     ins StringRefParameter<"struct name">:$name,
         ArrayRefParameter<"P4HIR::FieldInfo", "struct fields">:$elements,
+        "unsigned":$nestedFieldCount,
         OptionalParameter<"mlir::DictionaryAttr", "annotations">:$annotations
   );
 
@@ -406,33 +407,50 @@ class StructLikeType<string name, string typeMnemonic>
     TypeBuilder<(ins "llvm::StringRef":$name,
                      "llvm::ArrayRef<P4HIR::FieldInfo>":$fields,
                      CArg<"mlir::DictionaryAttr", "{}">:$annotations), [{
-      return $_get($_ctxt, name, fields,
+      // Compute nested field count once and store it for fast access.
+      unsigned nestedFieldCount = _computeNestedFieldCount(fields);
+      return $_get($_ctxt, name, fields, nestedFieldCount,
                    annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
     }]>
   ];
 
   string commonClassDeclaration = IndexableTypeInterface.extraClassDeclaration # [{
-    unsigned getFieldCount() {
+    static unsigned _computeNestedFieldCount(llvm::ArrayRef<P4HIR::FieldInfo> fields) {
+      unsigned nestedFieldCount = 0;
+
+      for (const auto &field : fields) {
+        // Count this field.
+        nestedFieldCount += 1;
+
+        // If this field is also indexable, count all nested sub-fields.
+        auto itype = mlir::dyn_cast<P4::P4MLIR::P4HIR::IndexableTypeInterface>(field.getType());
+        if (itype) nestedFieldCount += itype.getNestedFieldCount();
+      }
+
+      return nestedFieldCount;
+    }
+
+    unsigned getFieldCount() const {
       return getElements().size();
     }
 
-    mlir::Type getFieldType(unsigned index) {
+    mlir::Type getFieldType(unsigned index) const {
       return getElements()[index].type;
     }
 
-    std::string getFieldName(unsigned index) {
+    std::string getFieldName(unsigned index) const {
       return getElements()[index].name.getValue().str();
     }
 
-    mlir::StringAttr getFieldNameAttr(unsigned index) {
+    mlir::StringAttr getFieldNameAttr(unsigned index) const {
       return getElements()[index].name;
     }
 
-    mlir::DictionaryAttr getFieldAnnotations(unsigned index) {
+    mlir::DictionaryAttr getFieldAnnotations(unsigned index) const {
       return getElements()[index].annotations;
     }
 
-    std::optional<P4HIR::IndexedField> getFieldByName(mlir::StringRef fieldName) {
+    std::optional<P4::P4MLIR::P4HIR::IndexedField> getFieldByName(mlir::StringRef fieldName) const {
       for (auto field : getFields())
         if (field.getNameAttr() == fieldName) return field;
       return {};
@@ -875,16 +893,22 @@ def ArrayType : P4HIR_Type<"Array", "array", [
   }];
 
   let extraClassDeclaration = IndexableTypeInterface.extraClassDeclaration # [{
-    unsigned getFieldCount() {
+    unsigned getFieldCount() const {
       return getSize();
     }
 
-    mlir::Type getFieldType(unsigned index) {
+    mlir::Type getFieldType(unsigned index) const {
       return getElementType();
     }
 
     std::string getFieldName(unsigned index) const {
       return ("[" + llvm::Twine(index) + "]").str();
+    }
+
+    unsigned getNestedFieldCount() const {
+      auto itype = mlir::dyn_cast<P4::P4MLIR::P4HIR::IndexableTypeInterface>(getElementType());
+      unsigned nestedFieldCountPerElem = itype ? itype.getNestedFieldCount() : 1;
+      return nestedFieldCountPerElem * getSize();
     }
 
     mlir::TypedAttr getDefaultValue();

--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Types.td
@@ -411,115 +411,31 @@ class StructLikeType<string name, string typeMnemonic>
     }]>
   ];
 
-  string commonClassDeclaration = [{
-    mlir::Type getFieldType(mlir::StringRef fieldName) {
-      for (const auto &field : getElements())
-        if (field.name == fieldName) return field.type;
-       return {};
+  string commonClassDeclaration = IndexableTypeInterface.extraClassDeclaration # [{
+    unsigned getFieldCount() {
+      return getElements().size();
     }
 
-    std::optional<P4HIR::FieldInfo> getField(mlir::StringRef fieldName) {
-      for (const auto &field : getElements())
-        if (field.name == fieldName) return field;
-       return {};
+    mlir::Type getFieldType(unsigned index) {
+      return getElements()[index].type;
     }
 
-    llvm::ArrayRef<P4HIR::FieldInfo> getFields() {
-      return getElements();
+    std::string getFieldName(unsigned index) {
+      return getElements()[index].name.getValue().str();
     }
 
-    void getInnerTypes(mlir::SmallVectorImpl<mlir::Type> &types) {
-      for (const auto &field : getElements()) types.push_back(field.type);
+    mlir::StringAttr getFieldNameAttr(unsigned index) {
+      return getElements()[index].name;
     }
 
-    P4HIR::FieldInfo getFieldByID(unsigned fieldID) {
-      assert((fieldID != 0) && "invalid fieldID");
-      mlir::Type type = *this;
-      const P4HIR::FieldInfo *nestedField = nullptr;
-      while (fieldID) {
-        auto stype = mlir::dyn_cast<P4HIR::StructLikeTypeInterface>(type);
-        if (stype) {
-          auto [index, newFieldID] = stype.getIndexAndSubfieldID(fieldID);
-          nestedField = &stype.getFields()[index];
-          type = nestedField->type;
-          fieldID = newFieldID;
-        } else {
-          llvm::report_fatal_error("fieldID indexing into a non-struct type");
-        }
-      }
-      return *nestedField;
+    mlir::DictionaryAttr getFieldAnnotations(unsigned index) {
+      return getElements()[index].annotations;
     }
 
-    std::optional<unsigned> getFieldIndex(mlir::StringRef fieldName) {
-      llvm::ArrayRef<P4HIR::FieldInfo> elems = getElements();
-      for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
-        if (elems[idx].name == fieldName) return idx;
+    std::optional<P4HIR::IndexedField> getFieldByName(mlir::StringRef fieldName) {
+      for (auto field : getFields())
+        if (field.getName() == fieldName) return field;
       return {};
-    }
-
-    std::optional<unsigned> getFieldIndex(mlir::StringAttr fieldName) {
-      llvm::ArrayRef<P4HIR::FieldInfo> elems = getElements();
-      for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
-        if (elems[idx].name == fieldName) return idx;
-      return {};
-    }
-
-    // FieldID type interface implementation
-    std::pair<unsigned, llvm::SmallVector<unsigned>> getFieldIDsStruct() const {
-      unsigned fieldID = 0;
-      auto elements = getElements();
-      llvm::SmallVector<unsigned> fieldIDs;
-      fieldIDs.reserve(elements.size());
-      for (auto &element : elements) {
-          auto type = element.type;
-          fieldID += 1;
-          fieldIDs.push_back(fieldID);
-          // Increment the field ID for the next field by the number of subfields.
-          fieldID += FieldIdImpl::getMaxFieldID(type);
-      }
-      return {fieldID, fieldIDs};
-    }
-
-    std::pair<mlir::Type, unsigned> getSubTypeByFieldID(unsigned fieldID) const {
-      if (fieldID == 0) return {*this, 0};
-      auto [maxId, fieldIDs] = getFieldIDsStruct();
-      auto *it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
-      auto subfieldIndex = std::distance(fieldIDs.begin(), it);
-      auto subfieldType = getElements()[subfieldIndex].type;
-      auto subfieldID = fieldID - fieldIDs[subfieldIndex];
-      return {subfieldType, subfieldID};
-    }
-
-    unsigned getFieldID(unsigned index) const {
-      auto [maxId, fieldIDs] = getFieldIDsStruct();
-      return fieldIDs[index];
-    }
-
-    unsigned getMaxFieldID() const {
-      unsigned fieldID = 0;
-      for (const auto &field : getElements()) fieldID += 1 + FieldIdImpl::getMaxFieldID(field.type);
-      return fieldID;
-    }
-
-    unsigned getIndexForFieldID(unsigned fieldID) const {
-      assert(!getElements().empty() && "struct must have >0 fields");
-      auto [maxId, fieldIDs] = getFieldIDsStruct();
-      auto *it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
-      return std::distance(fieldIDs.begin(), it);
-    }
-
-    std::pair<unsigned, unsigned> getIndexAndSubfieldID(unsigned fieldID) const {
-      auto index = getIndexForFieldID(fieldID);
-      auto elementFieldID = getFieldID(index);
-      return {index, fieldID - elementFieldID};
-    }
-
-    std::pair<unsigned, bool> projectToChildFieldID(unsigned fieldID,
-                                                    unsigned index) const {
-      auto [maxId, fieldIDs] = getFieldIDsStruct();
-      auto childRoot = fieldIDs[index];
-      auto rangeEnd = index + 1 >= getElements().size() ? maxId : (fieldIDs[index + 1] - 1);
-      return std::make_pair(fieldID - childRoot, fieldID >= childRoot && fieldID <= rangeEnd);
     }
 
     // DestructurableTypeInterface implementation
@@ -934,7 +850,7 @@ def AliasType : P4HIR_Type<"Alias", "alias", [AnnotatedType]> {
 //===----------------------------------------------------------------------===//
 def ArrayType : P4HIR_Type<"Array", "array", [
   DeclareTypeInterfaceMethods<DestructurableTypeInterface>,
-  DeclareTypeInterfaceMethods<FieldIDTypeInterface>,
+  IndexableTypeInterface,
   HasDefaultValue
 ]> {
   let summary = "fixed-sized array";
@@ -958,7 +874,19 @@ def ArrayType : P4HIR_Type<"Array", "array", [
     `<` custom<Array>($size, $elementType) `>`
   }];
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = IndexableTypeInterface.extraClassDeclaration # [{
+    unsigned getFieldCount() {
+      return getSize();
+    }
+
+    mlir::Type getFieldType(unsigned index) {
+      return getElementType();
+    }
+
+    std::string getFieldName(unsigned index) const {
+      return ("[" + llvm::Twine(index) + "]").str();
+    }
+
     mlir::TypedAttr getDefaultValue();
   }];
 }

--- a/lib/Conversion/ConversionPatterns.cpp
+++ b/lib/Conversion/ConversionPatterns.cpp
@@ -92,22 +92,18 @@ P4HIRTypeConverter::P4HIRTypeConverter() {
     });
 
     addConversion([&](P4HIR::HeaderUnionType headerunionType) {
-        SmallVector<P4HIR::FieldInfo> newFields;
-        llvm::transform(headerunionType.getFields(), std::back_inserter(newFields),
-                        [&](auto field) -> P4HIR::FieldInfo {
-                            return {field.name, convertType(field.type), field.annotations};
-                        });
+        auto newFields = llvm::map_to_vector(headerunionType.getElements(), [&](auto field) {
+            return P4HIR::FieldInfo(field.name, convertType(field.type), field.annotations);
+        });
 
         return P4HIR::HeaderUnionType::get(headerunionType.getContext(), headerunionType.getName(),
                                            newFields, headerunionType.getAnnotations());
     });
 
     addConversion([&](P4HIR::HeaderType headerType) {
-        SmallVector<P4HIR::FieldInfo> newFields;
-        llvm::transform(headerType.getFields(), std::back_inserter(newFields),
-                        [&](auto field) -> P4HIR::FieldInfo {
-                            return {field.name, convertType(field.type), field.annotations};
-                        });
+        auto newFields = llvm::map_to_vector(headerType.getElements(), [&](auto field) {
+            return P4HIR::FieldInfo(field.name, convertType(field.type), field.annotations);
+        });
         // Remove validity bit field, it is added automatically
         newFields.pop_back();
 
@@ -116,11 +112,9 @@ P4HIRTypeConverter::P4HIRTypeConverter() {
     });
 
     addConversion([&](P4HIR::StructType structType) {
-        SmallVector<P4HIR::FieldInfo> newFields;
-        llvm::transform(structType.getFields(), std::back_inserter(newFields),
-                        [&](auto field) -> P4HIR::FieldInfo {
-                            return {field.name, convertType(field.type), field.annotations};
-                        });
+        auto newFields = llvm::map_to_vector(structType.getElements(), [&](auto field) {
+            return P4HIR::FieldInfo(field.name, convertType(field.type), field.annotations);
+        });
 
         return P4HIR::StructType::get(structType.getContext(), structType.getName(), newFields,
                                       structType.getAnnotations());

--- a/lib/Conversion/P4HIRToBMv2IR/P4HIRToBMv2IR.cpp
+++ b/lib/Conversion/P4HIRToBMv2IR/P4HIRToBMv2IR.cpp
@@ -45,8 +45,8 @@ struct P4HIRToBMv2IRTypeConverter : public mlir::TypeConverter {
         addConversion([&](mlir::Type t) { return t; });
         addConversion([&](P4HIR::HeaderType headerType) -> Type {
             SmallVector<BMv2IR::FieldInfo> newFields;
-            for (auto field : headerType.getFields()) {
-                if (!BMv2IR::HeaderType::isAllowedFieldType(field.type)) return nullptr;
+            for (auto field : headerType.getElements()) {
+                if (!BMv2IR::HeaderType::isAllowedFieldType(field.getType())) return nullptr;
                 newFields.push_back(convertFieldInfo(field));
             }
             return BMv2IR::HeaderType::get(headerType.getContext(), headerType.getName(),

--- a/lib/Dialect/P4HIR/CMakeLists.txt
+++ b/lib/Dialect/P4HIR/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_mlir_dialect_library(P4MLIR_P4HIR
+  FieldPath.cpp
   P4HIR_Ops.cpp
   P4HIR_Types.cpp
   P4HIR_Attrs.cpp

--- a/lib/Dialect/P4HIR/FieldPath.cpp
+++ b/lib/Dialect/P4HIR/FieldPath.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2025 The P4 Language Consortium
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "p4mlir/Dialect/P4HIR/FieldPath.h"
+
+#include "llvm/ADT/SmallString.h"
+
+using namespace P4::P4MLIR;
+
+using P4HIR::FieldPath;
+
+unsigned FieldPath::getMaxFieldID(mlir::Type type) {
+    auto itype = mlir::dyn_cast<P4HIR::IndexableTypeInterface>(type);
+    if (!itype) return 0;
+
+    unsigned maxFieldID = 0;
+    for (auto field : itype.getFields()) maxFieldID += 1 + getMaxFieldID(field.getType());
+
+    return maxFieldID;
+}
+
+unsigned FieldPath::getFieldID(P4HIR::IndexableTypeInterface itype, unsigned index) {
+    assert((index < itype.getFieldCount()) && "Invalid field index");
+    unsigned fid = 0;
+    unsigned i = 0;
+    unsigned e = itype.getFieldCount();
+
+    for (; i < e; i++) {
+        // Move `fid` to the fieldID of the current field.
+        fid += 1;
+
+        if (i == index) return fid;
+
+        // Increment the field ID for the next field by the number of subfields.
+        fid += getMaxFieldID(itype.getFieldType(i));
+    }
+
+    llvm_unreachable("Impossible state");
+    return 0;
+}
+
+FieldPath::IndexingResult FieldPath::indexInto(P4HIR::IndexableTypeInterface itype,
+                                               unsigned fieldID) {
+    assert((fieldID > 0 && fieldID <= getMaxFieldID(itype)) && "Invalid field ID");
+    unsigned fid = 0;
+    unsigned i = 0;
+    unsigned e = itype.getFieldCount();
+
+    for (; i < e; i++) {
+        // Move `fid` to the fieldID of the current field.
+        fid += 1;
+
+        // Compute the fieldID of the next field.
+        unsigned nextFid = fid + getMaxFieldID(itype.getFieldType(i));
+
+        // `fieldID` is in [fid, nextFid), we found what we're looking.
+        if (fieldID < nextFid) return IndexingResult(i, fid, fieldID - fid);
+
+        // Advance to next field.
+        fid = nextFid;
+    }
+
+    llvm_unreachable("Impossible state");
+    return IndexingResult(0, 0, 0);
+}
+
+FieldPath FieldPath::fromFieldID(mlir::Type rootType, unsigned fieldID) {
+    assert((fieldID < getMaxFieldID(rootType)) && "Invalid fieldID");
+    mlir::Type type = rootType;
+    unsigned rhsFid = fieldID;
+
+    while (rhsFid) {
+        auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
+        auto indexingResult = indexInto(itype, rhsFid);
+        type = itype.getFieldType(indexingResult.index);
+        rhsFid = indexingResult.childFieldId;
+    }
+
+    return FieldPath(rootType, type, fieldID);
+}
+
+P4HIR::FieldPath FieldPath::concat(const FieldPath &lhs, const FieldPath &rhs) {
+    assert(canConcat(lhs, rhs) && "Types cannot be concatenated");
+    if (lhs.isEmpty()) return rhs;
+    if (rhs.isEmpty()) return lhs;
+    return FieldPath(lhs.getRootType(), rhs.getLeafType(), lhs.getFieldID() + rhs.getFieldID());
+}
+
+std::pair<FieldPath, FieldPath> FieldPath::split(llvm::function_ref<bool(FieldPath)> pred) const {
+    FieldPath lhs;
+    bool notFound = forEach([&](FieldPath prefixPath) {
+        if (pred(prefixPath)) return false;
+
+        lhs = prefixPath;
+        return true;
+    });
+
+    if (notFound) return {*this, FieldPath()};
+    if (lhs.isEmpty()) return {FieldPath(), *this};
+
+    return {lhs, FieldPath(lhs.getLeafType(), getLeafType(), getFieldID() - lhs.getFieldID())};
+}
+
+FieldPath &FieldPath::append(unsigned index) {
+    auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(leafType);
+    fieldID += getFieldID(itype, index);
+    leafType = itype.getFieldType(index);
+    return *this;
+}
+
+bool FieldPath::forEach(llvm::function_ref<bool(FieldPath)> cb) const {
+    // Iteration invariant: (lhsFid + rhsFid) == getFieldID()
+    unsigned lhsFid = 0;
+    unsigned rhsFid = getFieldID();
+    mlir::Type type = getRootType();
+
+    // Visit root.
+    if (!cb(FieldPath(getRootType(), type, lhsFid))) return false;
+
+    while (rhsFid) {
+        auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
+        auto indexingResult = indexInto(itype, rhsFid);
+        type = itype.getFieldType(indexingResult.index);
+
+        if (!cb(FieldPath(getRootType(), type, lhsFid))) return false;
+
+        lhsFid += indexingResult.parentFieldId;
+        rhsFid = indexingResult.childFieldId;
+    }
+
+    return true;
+}
+
+bool FieldPath::forEachField(llvm::function_ref<bool(IndexedField)> cb) const {
+    mlir::Type type = getRootType();
+    unsigned rhsFid = getFieldID();
+
+    while (rhsFid) {
+        auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
+        auto indexingResult = indexInto(itype, rhsFid);
+
+        if (!cb(IndexedField(itype, indexingResult.index))) return false;
+
+        rhsFid = indexingResult.childFieldId;
+    }
+
+    return true;
+}
+
+std::string FieldPath::getIdentifier() const {
+    llvm::SmallString<64> name;
+    forEachField([&](auto field) {
+        name += ".";
+        name += field.getName();
+        return true;
+    });
+    return (std::string)name;
+}
+
+void FieldPath::print(llvm::raw_ostream &os) const { os << getIdentifier(); }

--- a/lib/Dialect/P4HIR/FieldPath.cpp
+++ b/lib/Dialect/P4HIR/FieldPath.cpp
@@ -8,51 +8,25 @@
 
 using namespace P4::P4MLIR;
 
+using P4HIR::FieldIDs;
 using P4HIR::FieldPath;
 
-unsigned FieldPath::getMaxFieldID(mlir::Type type) {
-    auto itype = mlir::dyn_cast<P4HIR::IndexableTypeInterface>(type);
-    if (!itype) return 0;
-
-    unsigned maxFieldID = 0;
-    for (auto field : itype.getFields()) maxFieldID += 1 + getMaxFieldID(field.getType());
-
-    return maxFieldID;
-}
-
-unsigned FieldPath::getFieldID(P4HIR::IndexableTypeInterface itype, unsigned index) {
+unsigned FieldIDs::getFieldID(P4HIR::IndexableTypeInterface itype, unsigned index) {
     assert((index < itype.getFieldCount()) && "Invalid field index");
-    unsigned fid = 0;
-    unsigned i = 0;
-    unsigned e = itype.getFieldCount();
 
-    for (; i < e; i++) {
-        // Move `fid` to the fieldID of the current field.
-        fid += 1;
-
-        if (i == index) return fid;
-
-        // Increment the field ID for the next field by the number of subfields.
-        fid += getMaxFieldID(itype.getFieldType(i));
-    }
+    for (auto [field, fieldID] : getFieldsWithIDs(itype))
+        if (field.getIndex() == index) return fieldID;
 
     llvm_unreachable("Impossible state");
     return 0;
 }
 
-FieldPath::IndexingResult FieldPath::indexInto(P4HIR::IndexableTypeInterface itype,
-                                               unsigned fieldID) {
-    assert((fieldID > 0 && fieldID <= getMaxFieldID(itype)) && "Invalid field ID");
-    unsigned fid = 0;
-    unsigned i = 0;
-    unsigned e = itype.getFieldCount();
-
-    for (; i < e; i++) {
-        // Move `fid` to the fieldID of the current field.
-        fid += 1;
-
-        // Compute the fieldID of the next field.
-        unsigned nextFid = fid + getMaxFieldID(itype.getFieldType(i));
+FieldIDs::IndexingResult FieldIDs::indexInto(P4HIR::IndexableTypeInterface itype,
+                                             unsigned fieldID) {
+    assert(FieldIDs::isValidField(itype, fieldID) && "Invalid field ID");
+    unsigned fid = 1;
+    for (unsigned i = 0, e = itype.getFieldCount(); i < e; i++) {
+        unsigned nextFid = FieldIDs::getNextFieldID(fid, itype, i);
 
         // `fieldID` is in [fid, nextFid), we found what we're looking.
         if (fieldID < nextFid) return IndexingResult(i, fid, fieldID - fid);
@@ -66,13 +40,13 @@ FieldPath::IndexingResult FieldPath::indexInto(P4HIR::IndexableTypeInterface ity
 }
 
 FieldPath FieldPath::fromFieldID(mlir::Type rootType, unsigned fieldID) {
-    assert((fieldID < getMaxFieldID(rootType)) && "Invalid fieldID");
+    assert(FieldIDs::isValid(rootType, fieldID) && "Invalid fieldID");
     mlir::Type type = rootType;
     unsigned rhsFid = fieldID;
 
     while (rhsFid) {
         auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
-        auto indexingResult = indexInto(itype, rhsFid);
+        auto indexingResult = FieldIDs::indexInto(itype, rhsFid);
         type = itype.getFieldType(indexingResult.index);
         rhsFid = indexingResult.childFieldId;
     }
@@ -80,81 +54,88 @@ FieldPath FieldPath::fromFieldID(mlir::Type rootType, unsigned fieldID) {
     return FieldPath(rootType, type, fieldID);
 }
 
-P4HIR::FieldPath FieldPath::concat(const FieldPath &lhs, const FieldPath &rhs) {
-    assert(canConcat(lhs, rhs) && "Types cannot be concatenated");
-    if (lhs.isEmpty()) return rhs;
-    if (rhs.isEmpty()) return lhs;
-    return FieldPath(lhs.getRootType(), rhs.getLeafType(), lhs.getFieldID() + rhs.getFieldID());
+static void forEachFieldPathImpl(FieldPath path, llvm::function_ref<void(FieldPath)> cb) {
+    cb(path);
+
+    auto itype = mlir::dyn_cast<P4HIR::IndexableTypeInterface>(path.getType());
+    if (!itype) return;
+
+    for (auto field : itype.getFields())
+        forEachFieldPathImpl(P4HIR::FieldPath::concat(path, field), cb);
+}
+
+void FieldPath::forEachFieldPath(mlir::Type type, llvm::function_ref<void(FieldPath)> cb) {
+    forEachFieldPathImpl(FieldPath(type), cb);
+}
+
+P4HIR::FieldPath &FieldPath::concat(FieldPath rhs) {
+    assert(canConcat(*this, rhs) && "Types cannot be concatenated");
+
+    if (isEmpty()) {
+        *this = rhs;
+    } else if (!rhs.isEmpty()) {
+        leafType = rhs.getType();
+        fieldID += rhs.getFieldID();
+    }
+
+    return *this;
 }
 
 std::pair<FieldPath, FieldPath> FieldPath::split(llvm::function_ref<bool(FieldPath)> pred) const {
     FieldPath lhs;
-    bool notFound = forEach([&](FieldPath prefixPath) {
-        if (pred(prefixPath)) return false;
-
+    bool doSplit = false;
+    for (auto prefixPath : iterPaths()) {
         lhs = prefixPath;
-        return true;
-    });
+        if (pred(prefixPath)) {
+            doSplit = true;
+            break;
+        }
+    }
 
-    if (notFound) return {*this, FieldPath()};
+    if (!doSplit) return {*this, FieldPath()};
     if (lhs.isEmpty()) return {FieldPath(), *this};
 
-    return {lhs, FieldPath(lhs.getLeafType(), getLeafType(), getFieldID() - lhs.getFieldID())};
+    return {lhs, FieldPath(lhs.getType(), getType(), getFieldID() - lhs.getFieldID())};
 }
 
-FieldPath &FieldPath::append(unsigned index) {
-    auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(leafType);
-    fieldID += getFieldID(itype, index);
-    leafType = itype.getFieldType(index);
-    return *this;
-}
-
-bool FieldPath::forEach(llvm::function_ref<bool(FieldPath)> cb) const {
-    // Iteration invariant: (lhsFid + rhsFid) == getFieldID()
-    unsigned lhsFid = 0;
-    unsigned rhsFid = getFieldID();
-    mlir::Type type = getRootType();
-
-    // Visit root.
-    if (!cb(FieldPath(getRootType(), type, lhsFid))) return false;
-
-    while (rhsFid) {
-        auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
-        auto indexingResult = indexInto(itype, rhsFid);
-        type = itype.getFieldType(indexingResult.index);
-
-        if (!cb(FieldPath(getRootType(), type, lhsFid))) return false;
-
-        lhsFid += indexingResult.parentFieldId;
-        rhsFid = indexingResult.childFieldId;
-    }
-
-    return true;
-}
-
-bool FieldPath::forEachField(llvm::function_ref<bool(IndexedField)> cb) const {
-    mlir::Type type = getRootType();
-    unsigned rhsFid = getFieldID();
-
-    while (rhsFid) {
-        auto itype = mlir::cast<P4HIR::IndexableTypeInterface>(type);
-        auto indexingResult = indexInto(itype, rhsFid);
-
-        if (!cb(IndexedField(itype, indexingResult.index))) return false;
-
-        rhsFid = indexingResult.childFieldId;
-    }
-
-    return true;
-}
-
-std::string FieldPath::getIdentifier() const {
-    llvm::SmallString<64> name;
-    forEachField([&](auto field) {
-        name += ".";
-        name += field.getName();
+bool FieldPath::try_append(unsigned index) {
+    if (auto itype = mlir::dyn_cast<P4HIR::IndexableTypeInterface>(leafType)) {
+        assert((index < itype.getFieldCount()) && "Out of bounds index");
+        fieldID += FieldIDs::getFieldID(itype, index);
+        leafType = itype.getFieldType(index);
         return true;
-    });
+    }
+
+    return false;
+}
+
+bool FieldPath::try_append(llvm::StringRef name) {
+    if (auto stype = mlir::dyn_cast<P4HIR::StructLikeTypeInterface>(leafType)) {
+        if (auto field = stype.getFieldByName(name)) {
+            fieldID += FieldIDs::getFieldID(stype, field->getIndex());
+            leafType = field->getType();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+FieldPath FieldPath::withRoot(mlir::Type newRootType) const {
+    if (isEmpty()) return *this;
+
+    FieldPath newPath(newRootType);
+    for (auto field : iterFields()) newPath.append(field.getIndex());
+
+    return newPath;
+}
+
+std::string FieldPath::getIdentifier(llvm::StringRef delimiter) const {
+    llvm::SmallString<64> name;
+    for (auto field : iterFields()) {
+        if (!name.empty()) name += delimiter;
+        name += field.getName();
+    }
     return (std::string)name;
 }
 

--- a/lib/Dialect/P4HIR/FieldPath.cpp
+++ b/lib/Dialect/P4HIR/FieldPath.cpp
@@ -84,7 +84,7 @@ P4HIR::FieldPath &FieldPath::concat(FieldPath rhs) {
 std::pair<FieldPath, FieldPath> FieldPath::split(llvm::function_ref<bool(FieldPath)> pred) const {
     FieldPath lhs;
     bool doSplit = false;
-    for (auto prefixPath : iterPaths()) {
+    for (auto prefixPath : paths()) {
         lhs = prefixPath;
         if (pred(prefixPath)) {
             doSplit = true;
@@ -125,17 +125,15 @@ FieldPath FieldPath::withRoot(mlir::Type newRootType) const {
     if (isEmpty()) return *this;
 
     FieldPath newPath(newRootType);
-    for (auto field : iterFields()) newPath.append(field.getIndex());
+    for (unsigned idx : field_indices()) newPath.append(idx);
 
     return newPath;
 }
 
 std::string FieldPath::getIdentifier(llvm::StringRef delimiter) const {
     llvm::SmallString<64> name;
-    for (auto field : iterFields()) {
-        if (!name.empty()) name += delimiter;
-        name += field.getName();
-    }
+    llvm::interleave(
+        fields(), [&](auto field) { name += field.getName(); }, [&]() { name += delimiter; });
     return (std::string)name;
 }
 

--- a/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Attrs.cpp
@@ -228,16 +228,16 @@ LogicalResult AggAttr::verify(function_ref<InFlightDiagnostic()> emitError, Type
 
     return llvm::TypeSwitch<mlir::Type, mlir::LogicalResult>(type)
         .Case<P4HIR::StructLikeTypeInterface>([&](auto structLike) {
-            if (failed(checkSize(structLike.getFields().size(), value.size()))) return failure();
+            if (failed(checkSize(structLike.getFieldCount(), value.size()))) return failure();
 
             for (auto [index, field] : llvm::enumerate(value.getValue())) {
                 if (auto typedField = mlir::dyn_cast<mlir::TypedAttr>(field)) {
-                    const auto &structField = structLike.getFields()[index];
-                    if (typedField.getType() != structField.type) {
-                        emitError()
-                            << "aggregate initializer type for struct field '" << structField.name
-                            << "' must match, expected: " << structField.type
-                            << ", got: " << typedField.getType();
+                    auto structField = structLike.getField(index);
+                    if (typedField.getType() != structField.getType()) {
+                        emitError() << "aggregate initializer type for struct field '"
+                                    << structField.getName()
+                                    << "' must match, expected: " << structField.getType()
+                                    << ", got: " << typedField.getType();
                         return failure();
                     }
                 } else {

--- a/lib/Dialect/P4HIR/P4HIR_Mangle.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Mangle.cpp
@@ -93,15 +93,16 @@ static void mangleTypes(llvm::raw_ostream &os,
     for (auto type : types) getNameImpl(os, type.second, ctx);
 }
 
-static void mangleFields(llvm::raw_ostream &os, llvm::ArrayRef<P4HIR::FieldInfo> fields,
-                         ManglingContext &ctx) {
+template <typename CollectionT>
+static void mangleFields(llvm::raw_ostream &os, CollectionT fields, ManglingContext &ctx) {
     for (auto field : fields) {
         // Do not mangle validity bit if any
-        if (mlir::isa<P4HIR::ValidBitType>(field.type)) continue;
+        if (mlir::isa<P4HIR::ValidBitType>(field.getType())) continue;
 
-        if (ctx.mangleFieldNames) mangleIdentifier(os, field.name, ctx);
-        getNameImpl(os, field.type, ctx);
-        if (ctx.mangleAnnotations && field.annotations) mangleAnnotations(os, field.annotations);
+        if (ctx.mangleFieldNames) mangleIdentifier(os, field.getName(), ctx);
+        getNameImpl(os, field.getType(), ctx);
+        if (ctx.mangleAnnotations && field.getAnnotations())
+            mangleAnnotations(os, field.getAnnotations());
     }
     os << "_";
 }

--- a/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
@@ -228,8 +228,8 @@ DeletionKind P4HIR::AssignOp::rewire(const DestructurableMemorySlot &slot,
     mlir::TypeSwitch<Type>(slot.elemType)
         .Case<StructLikeTypeInterface>([&](auto structType) {
             for (auto [idx, elt] : elements) {
-                auto &fieldInfo = structType.getFields()[idx];
-                auto val = P4HIR::StructExtractOp::create(builder, getLoc(), getValue(), fieldInfo);
+                auto field = structType.getField(idx);
+                auto val = P4HIR::StructExtractOp::create(builder, getLoc(), getValue(), field);
                 P4HIR::AssignOp::create(builder, getLoc(), val, elt);
             }
         })

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -1961,14 +1961,6 @@ void P4HIR::StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
     build(builder, odsState, field.getType(), input, field.getIndex());
 }
 
-void P4HIR::StructExtractOp::build(OpBuilder &builder, OperationState &odsState, Value input,
-                                   StringAttr fieldName) {
-    auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(input.getType());
-    auto field = structType.getFieldByName(fieldName);
-    assert(field.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, field->getType(), input, field->getIndex());
-}
-
 void P4HIR::StructExtractOp::getAsmResultNames(function_ref<void(Value, StringRef)> setNameFn) {
     setNameFn(getResult(), getFieldName());
 }
@@ -2050,19 +2042,9 @@ LogicalResult P4HIR::StructFieldRefOp::verify() {
 
 void P4HIR::StructFieldRefOp::build(OpBuilder &builder, OperationState &odsState, Value input,
                                     P4HIR::IndexedField field) {
-    auto structLikeType = mlir::cast<ReferenceType>(input.getType()).getObjectType();
-    auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(structLikeType);
+    auto structType = P4HIR::unref<P4HIR::StructLikeTypeInterface>(input.getType());
     assert((structType == field.getParentType()) && "Invalid field argument");
     build(builder, odsState, ReferenceType::get(field.getType()), input, field.getIndex());
-}
-
-void P4HIR::StructFieldRefOp::build(OpBuilder &builder, OperationState &odsState, Value input,
-                                    StringAttr fieldName) {
-    auto structLikeType = mlir::cast<ReferenceType>(input.getType()).getObjectType();
-    auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(structLikeType);
-    auto field = structType.getFieldByName(fieldName);
-    assert(field.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, ReferenceType::get(field->getType()), input, field->getIndex());
 }
 
 Value P4HIR::StructFieldRefOp::getViewSource() { return getInput(); }

--- a/lib/Dialect/P4HIR/P4HIR_Ops.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Ops.cpp
@@ -1788,8 +1788,7 @@ ParseResult P4HIR::StructOp::parse(OpAsmParser &parser, OperationState &result) 
     auto structType = mlir::dyn_cast<StructLikeTypeInterface>(declType);
     if (!structType) return parser.emitError(parser.getNameLoc(), "expected !p4hir.struct type");
 
-    llvm::SmallVector<Type, 4> structInnerTypes;
-    structType.getInnerTypes(structInnerTypes);
+    auto structInnerTypes = llvm::to_vector(structType.getFieldTypes());
     result.addTypes(structType);
 
     if (parser.resolveOperands(operands, structInnerTypes, inputOperandsLoc, result.operands))
@@ -1806,13 +1805,13 @@ void P4HIR::StructOp::print(OpAsmPrinter &printer) {
 }
 
 LogicalResult P4HIR::StructOp::verify() {
-    auto elements = mlir::cast<StructLikeTypeInterface>(getType()).getFields();
+    auto structLikeType = mlir::cast<StructLikeTypeInterface>(getType());
+    if (structLikeType.getFieldCount() != getInput().size())
+        return emitOpError("struct field count mismatch");
 
-    if (elements.size() != getInput().size()) return emitOpError("struct field count mismatch");
-
-    for (const auto &[field, value] : llvm::zip(elements, getInput()))
-        if (field.type != value.getType())
-            return emitOpError("struct field `") << field.name << "` type does not match";
+    for (auto [field, value] : llvm::zip(structLikeType.getElements(), getInput()))
+        if (field.getType() != value.getType())
+            return emitOpError("struct field `") << field.getName() << "` type does not match";
 
     return success();
 }
@@ -1853,13 +1852,12 @@ static LogicalResult verifyAggregateFieldIndexAndType(AggregateOp &op,
                                                       P4HIR::StructLikeTypeInterface aggType,
                                                       Type elementType) {
     auto index = op.getFieldIndex();
-    auto fields = aggType.getFields();
-    if (index >= fields.size())
+    if (index >= aggType.getFieldCount())
         return op.emitOpError() << "field index " << index
                                 << " exceeds element count of aggregate type";
 
-    if (elementType != fields[index].type)
-        return op.emitOpError() << "type " << fields[index].type
+    if (elementType != aggType.getFieldType(index))
+        return op.emitOpError() << "type " << aggType.getFieldType(index)
                                 << " of accessed field in aggregate at index " << index
                                 << " does not match expected type " << elementType;
 
@@ -1887,17 +1885,16 @@ static ParseResult parseExtractOp(OpAsmParser &parser, OperationState &result) {
         return failure();
     }
 
-    auto fieldIndex = aggType.getFieldIndex(fieldName);
-    if (!fieldIndex) {
+    auto field = aggType.getFieldByName(fieldName);
+    if (!field) {
         parser.emitError(parser.getNameLoc(),
                          "field name '" + fieldName.getValue() + "' not found in aggregate type");
         return failure();
     }
 
-    auto indexAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), *fieldIndex);
+    auto indexAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), field->getIndex());
     result.addAttribute("fieldIndex", indexAttr);
-    Type resultType = aggType.getFields()[*fieldIndex].type;
-    result.addTypes(resultType);
+    result.addTypes(field->getType());
 
     if (parser.resolveOperand(operand, declType, result.operands)) return failure();
     return success();
@@ -1918,16 +1915,16 @@ static ParseResult parseExtractRefOp(OpAsmParser &parser, OperationState &result
         parser.emitError(parser.getNameLoc(), "expected reference to aggregate type");
         return failure();
     }
-    auto fieldIndex = aggType.getFieldIndex(fieldName);
-    if (!fieldIndex) {
+    auto field = aggType.getFieldByName(fieldName);
+    if (!field) {
         parser.emitError(parser.getNameLoc(),
                          "field name '" + fieldName.getValue() + "' not found in aggregate type");
         return failure();
     }
 
-    auto indexAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), *fieldIndex);
+    auto indexAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), field->getIndex());
     result.addAttribute("fieldIndex", indexAttr);
-    Type resultType = P4HIR::ReferenceType::get(aggType.getFields()[*fieldIndex].type);
+    Type resultType = P4HIR::ReferenceType::get(field->getType());
     result.addTypes(resultType);
 
     if (parser.resolveOperand(operand, declType, result.operands)) return failure();
@@ -1958,20 +1955,18 @@ ParseResult P4HIR::StructExtractOp::parse(OpAsmParser &parser, OperationState &r
 void P4HIR::StructExtractOp::print(OpAsmPrinter &printer) { printExtractOp(printer, *this); }
 
 void P4HIR::StructExtractOp::build(OpBuilder &builder, OperationState &odsState, Value input,
-                                   P4HIR::FieldInfo field) {
+                                   P4HIR::IndexedField field) {
     auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(input.getType());
-    auto fieldIndex = structType.getFieldIndex(field.name);
-    assert(fieldIndex.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, field.type, input, *fieldIndex);
+    assert((structType == field.getParentType()) && "Invalid field argument");
+    build(builder, odsState, field.getType(), input, field.getIndex());
 }
 
 void P4HIR::StructExtractOp::build(OpBuilder &builder, OperationState &odsState, Value input,
                                    StringAttr fieldName) {
     auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(input.getType());
-    auto fieldIndex = structType.getFieldIndex(fieldName);
-    auto fieldType = structType.getFieldType(fieldName);
-    assert(fieldIndex.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, fieldType, input, *fieldIndex);
+    auto field = structType.getFieldByName(fieldName);
+    assert(field.has_value() && "field name not found in aggregate type");
+    build(builder, odsState, field->getType(), input, field->getIndex());
 }
 
 void P4HIR::StructExtractOp::getAsmResultNames(function_ref<void(Value, StringRef)> setNameFn) {
@@ -2054,22 +2049,20 @@ LogicalResult P4HIR::StructFieldRefOp::verify() {
 }
 
 void P4HIR::StructFieldRefOp::build(OpBuilder &builder, OperationState &odsState, Value input,
-                                    P4HIR::FieldInfo field) {
+                                    P4HIR::IndexedField field) {
     auto structLikeType = mlir::cast<ReferenceType>(input.getType()).getObjectType();
     auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(structLikeType);
-    auto fieldIndex = structType.getFieldIndex(field.name);
-    assert(fieldIndex.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, ReferenceType::get(field.type), input, *fieldIndex);
+    assert((structType == field.getParentType()) && "Invalid field argument");
+    build(builder, odsState, ReferenceType::get(field.getType()), input, field.getIndex());
 }
 
 void P4HIR::StructFieldRefOp::build(OpBuilder &builder, OperationState &odsState, Value input,
                                     StringAttr fieldName) {
     auto structLikeType = mlir::cast<ReferenceType>(input.getType()).getObjectType();
     auto structType = mlir::cast<P4HIR::StructLikeTypeInterface>(structLikeType);
-    auto fieldIndex = structType.getFieldIndex(fieldName);
-    auto fieldType = structType.getFieldType(fieldName);
-    assert(fieldIndex.has_value() && "field name not found in aggregate type");
-    build(builder, odsState, ReferenceType::get(fieldType), input, *fieldIndex);
+    auto field = structType.getFieldByName(fieldName);
+    assert(field.has_value() && "field name not found in aggregate type");
+    build(builder, odsState, ReferenceType::get(field->getType()), input, field->getIndex());
 }
 
 Value P4HIR::StructFieldRefOp::getViewSource() { return getInput(); }

--- a/lib/Dialect/P4HIR/P4HIR_TypeInterfaces.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_TypeInterfaces.cpp
@@ -6,54 +6,21 @@
 
 using namespace mlir;
 using namespace P4::P4MLIR::P4HIR;
-using namespace FieldIdImpl;
 
-mlir::Type FieldIdImpl::getFinalTypeByFieldID(mlir::Type type, unsigned fieldID) {
-    std::pair<Type, unsigned> pair(type, fieldID);
-    while (pair.second) {
-        if (auto ftype = dyn_cast<FieldIDTypeInterface>(pair.first))
-            pair = ftype.getSubTypeByFieldID(pair.second);
-        else
-            llvm::report_fatal_error("fieldID indexing into a non-aggregate type");
-    }
-    return pair.first;
+mlir::Type IndexedField::getType() const {
+    return mlir::cast<P4HIR::IndexableTypeInterface>(indexableType).getFieldType(index);
 }
 
-std::pair<Type, unsigned> FieldIdImpl::getSubTypeByFieldID(mlir::Type type, unsigned fieldID) {
-    if (!fieldID) return {type, 0};
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type))
-        return ftype.getSubTypeByFieldID(fieldID);
-
-    llvm::report_fatal_error("fieldID indexing into a non-aggregate type");
+std::string IndexedField::getName() const {
+    return mlir::cast<P4HIR::IndexableTypeInterface>(indexableType).getFieldName(index);
 }
 
-unsigned FieldIdImpl::getMaxFieldID(mlir::Type type) {
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type)) return ftype.getMaxFieldID();
-    return 0;
+mlir::StringAttr IndexedField::getNameAttr() const {
+    return mlir::cast<P4HIR::IndexableTypeInterface>(indexableType).getFieldNameAttr(index);
 }
 
-std::pair<unsigned, bool> FieldIdImpl::projectToChildFieldID(mlir::Type type, unsigned fieldID,
-                                                             unsigned index) {
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type))
-        return ftype.projectToChildFieldID(fieldID, index);
-    return {0, fieldID == 0};
-}
-
-unsigned FieldIdImpl::getIndexForFieldID(mlir::Type type, unsigned fieldID) {
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type)) return ftype.getIndexForFieldID(fieldID);
-    return 0;
-}
-
-unsigned FieldIdImpl::getFieldID(mlir::Type type, unsigned fieldID) {
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type)) return ftype.getFieldID(fieldID);
-    return 0;
-}
-
-std::pair<unsigned, unsigned> FieldIdImpl::getIndexAndSubfieldID(mlir::Type type,
-                                                                 unsigned fieldID) {
-    if (auto ftype = dyn_cast<FieldIDTypeInterface>(type))
-        return ftype.getIndexAndSubfieldID(fieldID);
-    return {0, fieldID == 0};
+mlir::DictionaryAttr IndexedField::getAnnotations() const {
+    return mlir::cast<P4HIR::IndexableTypeInterface>(indexableType).getFieldAnnotations(index);
 }
 
 #include "p4mlir/Dialect/P4HIR/P4HIR_TypeInterfaces.cpp.inc"

--- a/lib/Dialect/P4HIR/P4HIR_Types.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Types.cpp
@@ -56,7 +56,7 @@ llvm::hash_code hash_value(const FieldInfo &fi) {
 mlir::TypedAttr getStructLikeDefaultValue(StructLikeTypeInterface type) {
     llvm::SmallVector<mlir::Attribute> fieldDefaults;
     for (auto field : type.getFields()) {
-        auto hasDef = mlir::dyn_cast<HasDefaultValue>(field.type);
+        auto hasDef = mlir::dyn_cast<HasDefaultValue>(field.getType());
         if (!hasDef) return nullptr;
         auto defValue = hasDef.getDefaultValue();
         if (!defValue) return nullptr;
@@ -785,49 +785,18 @@ void printArray(mlir::AsmPrinter &p, ArrayType arrayType) {
     printArray(p, arrayType.getSize(), arrayType.getElementType());
 }
 
-LogicalResult ArrayType::verify(function_ref<InFlightDiagnostic()> emitError, size_t size,
-                                Type elementType) {
-    if (mlir::isa<ReferenceType>(elementType))
-        return emitError() << "p4hir.array cannot contain reference types";
-    return success();
-}
-
-unsigned ArrayType::getMaxFieldID() const {
-    return getSize() * (FieldIdImpl::getMaxFieldID(getElementType()) + 1);
-}
-
-std::pair<Type, unsigned> ArrayType::getSubTypeByFieldID(unsigned fieldID) const {
-    if (fieldID == 0) return {*this, 0};
-    return {getElementType(), getIndexAndSubfieldID(fieldID).second};
-}
-
-std::pair<unsigned, bool> ArrayType::projectToChildFieldID(unsigned fieldID, unsigned index) const {
-    auto childRoot = getFieldID(index);
-    auto rangeEnd = index >= getSize() ? getMaxFieldID() : (getFieldID(index + 1) - 1);
-    return std::make_pair(fieldID - childRoot, fieldID >= childRoot && fieldID <= rangeEnd);
-}
-
-unsigned ArrayType::getIndexForFieldID(unsigned fieldID) const {
-    assert(fieldID && "fieldID must be at least 1");
-    // Divide the field ID by the number of fieldID's per element.
-    return (fieldID - 1) / (FieldIdImpl::getMaxFieldID(getElementType()) + 1);
-}
-
-std::pair<unsigned, unsigned> ArrayType::getIndexAndSubfieldID(unsigned fieldID) const {
-    auto index = getIndexForFieldID(fieldID);
-    auto elementFieldID = getFieldID(index);
-    return {index, fieldID - elementFieldID};
-}
-
-unsigned ArrayType::getFieldID(unsigned index) const {
-    return 1 + index * (FieldIdImpl::getMaxFieldID(getElementType()) + 1);
-}
-
 std::optional<DenseMap<Attribute, Type>> ArrayType::getSubelementIndexMap() const {
     DenseMap<Attribute, Type> destructured;
     for (unsigned i = 0; i < getSize(); ++i)
         destructured.insert({IntegerAttr::get(IndexType::get(getContext()), i), getElementType()});
     return destructured;
+}
+
+LogicalResult ArrayType::verify(function_ref<InFlightDiagnostic()> emitError, size_t size,
+                                Type elementType) {
+    if (mlir::isa<ReferenceType>(elementType))
+        return emitError() << "p4hir.array cannot contain reference types";
+    return success();
 }
 
 Type ArrayType::getTypeAtIndex(Attribute) const { return getElementType(); }

--- a/lib/Dialect/P4HIR/P4HIR_Types.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_Types.cpp
@@ -336,7 +336,7 @@ Type HeaderType::parse(AsmParser &p) {
     mlir::DictionaryAttr annotations;
     if (parseFields(p, name, parameters, annotations)) return {};
     // Do not use our own get() here as it adds __validity bit. And we do have it already.
-    return Base::get(p.getContext(), name, parameters,
+    return Base::get(p.getContext(), name, parameters, _computeNestedFieldCount(parameters),
                      annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
 }
 
@@ -370,7 +370,8 @@ void HeaderStackType::print(AsmPrinter &p) const {
 }
 
 LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError, StringRef,
-                                 ArrayRef<FieldInfo> elements, DictionaryAttr) {
+                                 ArrayRef<FieldInfo> elements, unsigned nestedFieldCount,
+                                 DictionaryAttr) {
     llvm::SmallDenseSet<StringAttr> fieldNameSet;
     LogicalResult result = success();
     fieldNameSet.reserve(elements.size());
@@ -380,11 +381,15 @@ LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError, S
             emitError() << "duplicate field name '" << elt.name.getValue()
                         << "' in p4hir.struct type";
         }
+    if (nestedFieldCount != _computeNestedFieldCount(elements))
+        emitError() << "Incorrect cached value for nested field count";
+
     return result;
 }
 
 LogicalResult HeaderType::verify(function_ref<InFlightDiagnostic()> emitError, StringRef,
-                                 ArrayRef<FieldInfo> elements, DictionaryAttr) {
+                                 ArrayRef<FieldInfo> elements, unsigned nestedFieldCount,
+                                 DictionaryAttr) {
     if (elements.empty()) {
         emitError() << "empty p4hir.header type";
         return failure();
@@ -400,6 +405,8 @@ LogicalResult HeaderType::verify(function_ref<InFlightDiagnostic()> emitError, S
                         << "' in p4hir.header type";
         }
     }
+    if (nestedFieldCount != _computeNestedFieldCount(elements))
+        emitError() << "Incorrect cached value for nested field count";
 
     auto lastField = elements.back();
     if (lastField.name != validityBit || !mlir::isa<P4HIR::ValidBitType>(lastField.type)) {
@@ -468,7 +475,8 @@ LogicalResult HeaderType::verify(function_ref<InFlightDiagnostic()> emitError, S
 }
 
 LogicalResult HeaderUnionType::verify(function_ref<InFlightDiagnostic()> emitError, StringRef,
-                                      ArrayRef<FieldInfo> elements, DictionaryAttr) {
+                                      ArrayRef<FieldInfo> elements, unsigned nestedFieldCount,
+                                      DictionaryAttr) {
     llvm::SmallDenseSet<StringAttr> fieldNameSet;
     LogicalResult result = success();
     fieldNameSet.reserve(elements.size());
@@ -486,6 +494,8 @@ LogicalResult HeaderUnionType::verify(function_ref<InFlightDiagnostic()> emitErr
                         << "' must be a header type";
         }
     }
+    if (nestedFieldCount != _computeNestedFieldCount(elements))
+        emitError() << "Incorrect cached value for nested field count";
 
     if (elements.empty()) {
         emitError() << "empty p4hir.header_union type";
@@ -496,7 +506,8 @@ LogicalResult HeaderUnionType::verify(function_ref<InFlightDiagnostic()> emitErr
 }
 
 LogicalResult HeaderStackType::verify(function_ref<InFlightDiagnostic()> emitError, StringRef,
-                                      ArrayRef<FieldInfo> elements, DictionaryAttr) {
+                                      ArrayRef<FieldInfo> elements, unsigned nestedFieldCount,
+                                      DictionaryAttr) {
     if (elements.size() != 2) {
         emitError() << "invalid struct size for header stack";
         return failure();
@@ -504,6 +515,9 @@ LogicalResult HeaderStackType::verify(function_ref<InFlightDiagnostic()> emitErr
 
     FieldInfo dataField = elements.front();
     FieldInfo nextIndexField = elements.back();
+
+    if (nestedFieldCount != _computeNestedFieldCount(elements))
+        emitError() << "Incorrect cached value for nested field count";
 
     auto arrayType = mlir::dyn_cast<P4HIR::ArrayType>(dataField.type);
     if (!arrayType ||
@@ -537,8 +551,8 @@ HeaderStackType HeaderStackType::get(mlir::MLIRContext *context, size_t sz,
     FieldInfo dataField(mlir::StringAttr::get(context, dataFieldName), dataType);
     FieldInfo nextIndexField(mlir::StringAttr::get(context, nextIndexFieldName),
                              P4HIR::BitsType::get(context, 32, false));
-
-    return Base::get(context, "hs", ArrayRef{dataField, nextIndexField}, nullptr);
+    SmallVector<FieldInfo> elements = {dataField, nextIndexField};
+    return Base::get(context, "hs", elements, _computeNestedFieldCount(elements), nullptr);
 }
 
 ArrayType HeaderStackType::getDataType() const {
@@ -610,7 +624,7 @@ HeaderType HeaderType::get(mlir::MLIRContext *context, llvm::StringRef name,
     realFields.emplace_back(mlir::StringAttr::get(context, validityBit),
                             P4HIR::ValidBitType::get(context));
 
-    return Base::get(context, name, realFields,
+    return Base::get(context, name, realFields, _computeNestedFieldCount(realFields),
                      annotations && !annotations.empty() ? annotations : mlir::DictionaryAttr());
 }
 

--- a/lib/P4C/translate.cpp
+++ b/lib/P4C/translate.cpp
@@ -643,11 +643,9 @@ mlir::TypedAttr P4HIRConverter::getOrCreateConstantExpr(const P4::IR::Expression
         auto base = mlir::cast<P4HIR::AggAttr>(getOrCreateConstantExpr(m->expr));
         auto structType = mlir::cast<P4HIR::StructType>(base.getType());
 
-        if (auto maybeIdx = structType.getFieldIndex(m->member.string_view())) {
-            auto field = base.getFields()[*maybeIdx];
-            auto fieldType = structType.getFieldType(m->member.string_view());
-
-            return setConstantExpr(expr, getTypedConstant(fieldType, field));
+        if (auto field = structType.getFieldByName(m->member.string_view())) {
+            auto attr = base.getFields()[field->getIndex()];
+            return setConstantExpr(expr, getTypedConstant(field->getType(), attr));
         } else
             BUG("invalid member reference %1%", m);
     }
@@ -1090,16 +1088,16 @@ P4HIR::CmpOp P4HIRConverter::emitHeaderUnionIsValidCmpOp(mlir::Location loc,
         [&](size_t fieldIndex) -> mlir::Value {
         auto headerUnionType = mlir::cast<P4HIR::HeaderUnionType>(getObjectType(headerUnion));
         // If all the fields were checked, return false
-        if (fieldIndex >= headerUnionType.getFields().size()) {
+        if (fieldIndex >= headerUnionType.getFieldCount()) {
             return getBoolConstant(loc, false);
         }
 
-        auto fieldInfo = headerUnionType.getFields()[fieldIndex];
+        auto field = headerUnionType.getField(fieldIndex);
         mlir::Value header;
         if (mlir::isa<P4HIR::ReferenceType>(headerUnion.getType())) {
-            header = P4HIR::StructFieldRefOp::create(builder, loc, headerUnion, fieldInfo.name);
+            header = P4HIR::StructFieldRefOp::create(builder, loc, headerUnion, field);
         } else {
-            header = P4HIR::StructExtractOp::create(builder, loc, headerUnion, fieldInfo.name);
+            header = P4HIR::StructExtractOp::create(builder, loc, headerUnion, field);
         }
 
         // Check if this member header is valid
@@ -1133,10 +1131,9 @@ P4HIR::CmpOp P4HIRConverter::emitHeaderUnionIsValidCmpOp(mlir::Location loc,
 void P4HIRConverter::emitSetInvalidForAllHeaders(mlir::Location loc, mlir::Value headerUnion,
                                                  const P4::cstring headerNameToSkip) {
     auto headerUnionType = mlir::cast<P4HIR::HeaderUnionType>(getObjectType(headerUnion));
-    llvm::for_each(headerUnionType.getFields(), [&](P4HIR::FieldInfo fieldInfo) {
-        if (headerNameToSkip != fieldInfo.name.getValue()) {
-            auto header =
-                P4HIR::StructFieldRefOp::create(builder, loc, headerUnion, fieldInfo.name);
+    llvm::for_each(headerUnionType.getFields(), [&](P4HIR::IndexedField field) {
+        if (headerNameToSkip != field.getName()) {
+            auto header = P4HIR::StructFieldRefOp::create(builder, loc, headerUnion, field);
             emitHeaderValidityBitAssignOp(loc, header, P4HIR::ValidityBit::Invalid);
         }
     });
@@ -2225,8 +2222,8 @@ bool P4HIRConverter::preorder(const P4::IR::StructExpression *str) {
     auto loc = getLoc(str);
 
     llvm::MapVector<mlir::StringAttr, mlir::Value> namedFields;
-    for (const auto &field : structType.getFields()) {
-        namedFields[field.name] = {};
+    for (auto field : structType.getFields()) {
+        namedFields[field.getNameAttr()] = {};
     }
 
     for (const auto *field : str->components)

--- a/lib/Transforms/ExpandEmit.cpp
+++ b/lib/Transforms/ExpandEmit.cpp
@@ -48,10 +48,9 @@ struct ExpandEmitPattern : public mlir::OpRewritePattern<P4CoreLib::PacketEmitOp
             })
             .Case<P4HIR::HeaderUnionType, P4HIR::StructType>(
                 [&](P4HIR::StructLikeTypeInterface tp) -> mlir::LogicalResult {
-                    auto elements = tp.getFields();
-                    for (const auto &elt : elements) {
+                    for (auto elt : tp.getFields()) {
                         auto extrData =
-                            P4HIR::StructExtractOp::create(rewriter, loc, emitArg, elt.name);
+                            P4HIR::StructExtractOp::create(rewriter, loc, emitArg, elt.getName());
                         if (!mlir::isa<P4HIR::StructLikeTypeInterface>(extrData.getType()))
                             return emitOp.emitOpError() << "Invalid type contained in emit call";
                         P4CoreLib::PacketEmitOp::create(rewriter, loc, dstPkt, extrData);

--- a/lib/Transforms/TupleToStruct.cpp
+++ b/lib/Transforms/TupleToStruct.cpp
@@ -44,10 +44,9 @@ class TupleToStructTypeConverter : public P4HIRTypeConverter {
             }
 
             SmallVector<P4HIR::FieldInfo> structFields;
-            mlir::StringAttr name;
-
             for (auto [index, type] : llvm::enumerate(convertedElements)) {
-                name = mlir::StringAttr::get(ctx, "element_" + std::to_string(index));
+                mlir::StringAttr name =
+                    mlir::StringAttr::get(ctx, "element_" + std::to_string(index));
                 structFields.emplace_back(name, type);
             }
             return P4HIR::StructType::get(ctx, "_tupleToStruct", structFields);
@@ -83,11 +82,11 @@ struct TupleExtractOpConversion : public OpConversionPattern<P4HIR::TupleExtract
         if (!structType)
             return rewriter.notifyMatchFailure(op, "expected P4HIR StructType as input operand");
 
-        if (index >= structType.getFields().size())
+        if (index >= structType.getFieldCount())
             return rewriter.notifyMatchFailure(op, "index out of bounds in P4HIR StructType");
 
         rewriter.replaceOpWithNewOp<P4HIR::StructExtractOp>(op, input,
-                                                            structType.getFields()[index].name);
+                                                            structType.getField(index).getName());
         return success();
     }
 };

--- a/test/Transforms/Passes/remove-aliases-error.mlir
+++ b/test/Transforms/Passes/remove-aliases-error.mlir
@@ -49,7 +49,7 @@ module {
 
 // CHECK: module
 module {
-  // expected-error@below {{aggregate initializer type for struct field '"t2"' must match, expected: '!p4hir.alias<"N32", !p4hir.bit<32>>', got: '!p4hir.bit<32>'}}
+  // expected-error@below {{aggregate initializer type for struct field 't2' must match, expected: '!p4hir.alias<"N32", !p4hir.bit<32>>', got: '!p4hir.bit<32>'}}
   %agg = p4hir.const #p4hir.aggregate<[#int1_b32i, #int1_b32i]> : !T
 }
 


### PR DESCRIPTION
This PR consists of:
 - A new helper class `FieldPath` to model an arbitrary field access path within a type with fields and provide useful methods to operate on such paths.
 - A simplification / unification of our type-with-fields interfaces.

Some of the rationale and design choice for the interface refactoring:
 - We were missing a "this type can be indexed into" interface that can reasonably cover both Arrays and  Struct-like types. This is especially important for a `FieldPath` implementation, since without that we wouldn't be able to model a path of an element in an array within a struct, which is a totally normal P4 construct. As such, implementing any relevant transformation (e.g. struct flattening) would be problematic or limited.
 - The previous `FieldIDTypeInterface` was complicated to implement and too low-level to be useful. It didn't expose the most commonly needed functionality, so it most code would just cast to StructLikeType or ArrayType instead.

Under this new implementation:
 - `IndexableTypeInterface` is trivially easy to implement and each provided function is easy enough to understand that it is self-ocumenting.
 - `IndexedField` is a new struct that represents the field access within an `IndexableTypeInterface`. It is essentially just a wrapper that conveniently provides the `IndexableTypeInterface` functionality for a particular field. Crucially, it is also meant to represent an array element (or any user-defined indexable type results). This is meant to replace almost all uses of `FieldInfo`.
 - `FieldInfo` is now only meant to be used to construct StructLike types (so I'm considering renaming it to `StructFieldInfo`).
 - `StructLikeTypeInterface` is now a thin wrapper on top of `IndexableTypeInterface`. I've kept it so that code can still easily check for struct-like types, wherever that makes sense. It also has couple additional methods.
 - The fieldID related infrastructure is now implemented separately within `FieldPath`. We only need an indexable-type and we can implement all fieldID calculations without user code, since the most important primitive that needs to exist is `getMaxFieldID` and that can be recursively computed by calling `getFieldCount()`.