### PR TITLE
Implement PromotableMemOpInterface for AssignSliceOp and ReadSliceOp

### DIFF
--- a/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
+++ b/include/p4mlir/Dialect/P4HIR/P4HIR_Ops.td
@@ -234,7 +234,8 @@ def AssignOp : P4HIR_Op<"assign", [
   // FIXME: add verifier.
 }
 
-def AssignSliceOp : P4HIR_Op<"assign_slice", []> {
+def AssignSliceOp : P4HIR_Op<"assign_slice",
+                    [DeclareOpInterfaceMethods<PromotableMemOpInterface>]> {
   let summary = "Assign a slice of values to variable";
   let description = [{
     ..
@@ -1286,6 +1287,7 @@ def SliceOp : P4HIR_Op<"slice",
 
 def ReadSliceOp : P4HIR_Op<"read_slice",
     [Pure,
+     DeclareOpInterfaceMethods<PromotableMemOpInterface>,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Extract a range or single bits from a referenced value";
   let description = [{

--- a/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
+++ b/lib/Dialect/P4HIR/P4HIR_MemorySlot.cpp
@@ -251,6 +251,89 @@ LogicalResult P4HIR::AssignOp::ensureOnlySafeAccesses(const MemorySlot &slot,
                                                       const DataLayout &dataLayout) {
     return success();
 }
+
+//===----------------------------------------------------------------------===//
+// Interfaces for AssignSliceOp
+//===----------------------------------------------------------------------===//
+
+// Read-modify-write of the whole slot
+bool P4HIR::AssignSliceOp::loadsFrom(const MemorySlot &slot) { return getRef() == slot.ptr; }
+
+bool P4HIR::AssignSliceOp::storesTo(const MemorySlot &slot) { return getRef() == slot.ptr; }
+
+Value P4HIR::AssignSliceOp::getStored(const MemorySlot &slot, OpBuilder &builder, Value reachingDef,
+                                      const DataLayout &dataLayout) {
+    auto elemType = llvm::cast<P4HIR::BitsType>(slot.elemType);
+    unsigned width = elemType.getWidth();
+    unsigned hi = getHighBit(), lo = getLowBit();
+
+    Value result = getValue();
+
+    if (lo > 0) {
+        auto lowType = P4HIR::BitsType::get(getContext(), lo, false);
+        Value low = P4HIR::SliceOp::create(builder, getLoc(), lowType, reachingDef, lo - 1, 0);
+        result = P4HIR::ConcatOp::create(builder, getLoc(), result, low);
+    }
+
+    if (hi + 1 < width) {
+        auto highType = P4HIR::BitsType::get(getContext(), width - 1 - hi, false);
+        Value high =
+            P4HIR::SliceOp::create(builder, getLoc(), highType, reachingDef, width - 1, hi + 1);
+        result = P4HIR::ConcatOp::create(builder, getLoc(), high, result);
+    }
+
+    if (result.getType() != elemType)
+        result = P4HIR::CastOp::create(builder, getLoc(), elemType, result);
+
+    return result;
+}
+
+bool P4HIR::AssignSliceOp::canUsesBeRemoved(const MemorySlot &slot,
+                                            const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                                            SmallVectorImpl<OpOperand *> &newBlockingUses,
+                                            const DataLayout &dataLayout) {
+    if (blockingUses.size() != 1) return false;
+    Value blockingUse = (*blockingUses.begin())->get();
+    return blockingUse == slot.ptr && getRef() == slot.ptr;
+}
+
+DeletionKind P4HIR::AssignSliceOp::removeBlockingUses(
+    const MemorySlot &slot, const SmallPtrSetImpl<OpOperand *> &blockingUses, OpBuilder &builder,
+    Value reachingDefinition, const DataLayout &dataLayout) {
+    return DeletionKind::Delete;
+}
+
+//===----------------------------------------------------------------------===//
+// Interfaces for ReadSliceOp
+//===----------------------------------------------------------------------===//
+
+bool P4HIR::ReadSliceOp::loadsFrom(const MemorySlot &slot) { return getInput() == slot.ptr; }
+
+bool P4HIR::ReadSliceOp::storesTo(const MemorySlot &slot) { return false; }
+
+Value P4HIR::ReadSliceOp::getStored(const MemorySlot &slot, OpBuilder &builder, Value reachingDef,
+                                    const DataLayout &dataLayout) {
+    llvm_unreachable("getStored should not be called on ReadSliceOp");
+}
+
+bool P4HIR::ReadSliceOp::canUsesBeRemoved(const MemorySlot &slot,
+                                          const SmallPtrSetImpl<OpOperand *> &blockingUses,
+                                          SmallVectorImpl<OpOperand *> &newBlockingUses,
+                                          const DataLayout &dataLayout) {
+    if (blockingUses.size() != 1) return false;
+    Value blockingUse = (*blockingUses.begin())->get();
+    return blockingUse == slot.ptr && getInput() == slot.ptr;
+}
+
+DeletionKind P4HIR::ReadSliceOp::removeBlockingUses(
+    const MemorySlot &slot, const SmallPtrSetImpl<OpOperand *> &blockingUses, OpBuilder &builder,
+    Value reachingDefinition, const DataLayout &dataLayout) {
+    Value slice = P4HIR::SliceOp::create(builder, getLoc(), getType(), reachingDefinition,
+                                         getHighBit(), getLowBit());
+    getResult().replaceAllUsesWith(slice);
+    return DeletionKind::Delete;
+}
+
 //===----------------------------------------------------------------------===//
 // Interfaces for StructFieldRefOp
 //===----------------------------------------------------------------------===//

--- a/test/Transforms/Passes/mem2reg.mlir
+++ b/test/Transforms/Passes/mem2reg.mlir
@@ -5,11 +5,22 @@
 // RUN: p4mlir-opt --pass-pipeline='builtin.module(any(mem2reg))' < %s | FileCheck %s
 !i32i = !p4hir.int<32>
 !b9i = !p4hir.bit<9>
+!b8i = !p4hir.bit<8>
+!b16i = !p4hir.bit<16>
 !PortId_t = !p4hir.struct<"PortId_t", _v: !b9i>
 #false = #p4hir.bool<false> : !p4hir.bool
 #true = #p4hir.bool<true> : !p4hir.bool
 #int100500_i32i = #p4hir.int<100500> : !i32i
 #int42_i32i = #p4hir.int<42> : !i32i
+#int0_b16i = #p4hir.int<0> : !b16i
+#int171_b8i = #p4hir.int<171> : !b8i
+#int205_b8i = #p4hir.int<205> : !b8i
+// CHECK: #[[$ATTR_0:.+]] = #p4hir.bool<false> : !p4hir.bool
+// CHECK: #[[$ATTR_1:.+]] = #p4hir.bool<true> : !p4hir.bool
+// CHECK: #[[$ATTR_205:.+]] = #p4hir.int<205> : !b8i
+// CHECK: #[[$ATTR_171:.+]] = #p4hir.int<171> : !b8i
+// CHECK: #[[$ATTR_9w0:.+]] = #p4hir.int<0> : !b16i
+// CHECK: #[[$ATTR_5:.+]] = #p4hir.int<0> : !b9i
 module {
   // CHECK-LABEL: p4hir.func @ifthen
   p4hir.func @ifthen() {
@@ -56,5 +67,28 @@ module {
     %field.ref = p4hir.struct_field_ref %p1 ["_v"] : <!PortId_t>
     %b = p4hir.read %field.ref : <!b9i>
     p4hir.return %b : !b9i
+  }
+
+  // CHECK-LABEL:   p4hir.func @slice_var()
+  // CHECK:           %[[VAL_0:.*]] = p4hir.const #[[$ATTR_9w0]]
+  // CHECK:           %[[VAL_1:.*]] = p4hir.const #[[$ATTR_171]]
+  // CHECK:           %[[VAL_2:.*]] = p4hir.slice %[[VAL_0]][15 : 8] : !b16i -> !b8i
+  // CHECK:           %[[VAL_3:.*]] = p4hir.concat(%[[VAL_2]] : !b8i, %[[VAL_1]] : !b8i) : !b16i
+  // CHECK:           %[[VAL_4:.*]] = p4hir.const #[[$ATTR_205]]
+  // CHECK:           %[[VAL_5:.*]] = p4hir.slice %[[VAL_3]][7 : 0] : !b16i -> !b8i
+  // CHECK:           %[[VAL_6:.*]] = p4hir.concat(%[[VAL_4]] : !b8i, %[[VAL_5]] : !b8i) : !b16i
+  // CHECK:           %[[VAL_7:.*]] = p4hir.slice %[[VAL_6]][7 : 0] : !b16i -> !b8i
+  // CHECK:           p4hir.return %[[VAL_7]]
+  // CHECK:         }
+  p4hir.func @slice_var() -> !b8i {
+    %v = p4hir.variable ["v", init] : <!b16i>
+    %c0 = p4hir.const #int0_b16i
+    p4hir.assign %c0, %v : <!b16i>
+    %cab = p4hir.const #int171_b8i
+    p4hir.assign_slice %cab, %v[7 : 0] : !b8i -> <!b16i>
+    %ccd = p4hir.const #int205_b8i
+    p4hir.assign_slice %ccd, %v[15 : 8] : !b8i -> <!b16i>
+    %r = p4hir.read_slice %v[7 : 0] : <!b16i> -> !b8i
+    p4hir.return %r : !b8i
   }
 }


### PR DESCRIPTION
Implements `PromotableMemOpInterface` on `AssignSliceOp` and `ReadSliceOp`, allowing mem2reg to promote variables accessed through them.